### PR TITLE
replace version with latest version in Packageinfo

### DIFF
--- a/Server/uploadpackage.R
+++ b/Server/uploadpackage.R
@@ -54,7 +54,10 @@ observeEvent(input$uploaded_file, {
              stringsAsFactors = FALSE)
   names(pkgs_file) <- tolower(names(pkgs_file))
   pkgs_file$package <- trimws(pkgs_file$package)
-  pkgs_file$version <- trimws(pkgs_file$version)
+  # pkgs_file$version <- trimws(pkgs_file$version)
+  # replace version with the latest version in Packageinfo
+  pkgs_file$version <- NULL
+  pkgs_file <- db_fun("SELECT package, version FROM Packageinfo") %>% left_join(pkgs_file, . , by = "package")
   values$Total <- pkgs_file
   pkgs_db1 <- db_fun("SELECT package FROM Packageinfo")
   values$Dup <- filter(values$Total, values$Total$package %in% pkgs_db1$package)


### PR DESCRIPTION
This is an addon to #8 Implement Package version functionality
It will display the latest version of the package instead of the one provided in the packages.csv file