### PR TITLE
update community usage metrics by selected version

### DIFF
--- a/Server/communityusage_metrics.R
+++ b/Server/communityusage_metrics.R
@@ -17,30 +17,28 @@ observe({
     # Load the columns into values$riskmetrics.
     pkgs_in_db <- db_fun(paste0("SELECT DISTINCT cum_id FROM CommunityUsageMetrics"))
     
-    if (values$selected_pkg$package %in% pkgs_in_db$cum_id &&
+    if (input$select_pack %in% pkgs_in_db$cum_id &&
         !identical(pkgs_in_db$cum_id, character(0))) {
       values$riskmetrics_cum <-
         db_fun(
           paste0(
-            "SELECT * FROM CommunityUsageMetrics WHERE cum_id ='",
-            values$selected_pkg$package,
-            "'"
+            "SELECT * FROM CommunityUsageMetrics",
+            " WHERE cum_id ='", values$selected_pkg$package, "'",
+            " AND cum_ver = '", values$selected_pkg$version, "'", ""
           )
         )
     } else{
-      if (values$selected_pkg$package != "Select") {
-        metric_cum_Info_upload_to_DB(input$select_pack, input$select_ver)
-        values$riskmetrics_cum <-
-          db_fun(
-            paste0(
-              "SELECT * FROM CommunityUsageMetrics WHERE cum_id ='",
-              values$selected_pkg$package,
-              "'"
-            )
+      metric_cum_Info_upload_to_DB(values$selected_pkg$package, values$selected_pkg$version)
+      values$riskmetrics_cum <-
+        db_fun(
+          paste0(
+            "SELECT * FROM CommunityUsageMetrics",
+            " WHERE cum_id ='", values$selected_pkg$package, "'",
+            " AND cum_ver = '", values$selected_pkg$version, "'", ""
           )
-      }
+        )
     }
-    
+
     # Load the data table column into reactive variable for time sice first release.
     values$time_since_first_release_info <-
       values$riskmetrics_cum$time_since_first_release[1]
@@ -200,25 +198,17 @@ values$cum_comment_submitted <- "no"
 
 observeEvent(input$submit_cum_comment, {
   if (trimws(input$cum_comment) != "") {
-    db_fun(
+    db_ins(
       paste0(
         "INSERT INTO Comments values('",
-        input$select_pack,
-        "',",
-        "'",
-        values$name,
-        "'," ,
-        "'",
-        values$role,
-        "',",
-        "'",
-        input$cum_comment,
-        "',",
-        "'cum',",
-        "'",
-        TimeStamp(),
-        "'"  ,
-        ")" 
+        input$select_pack, "',",
+        "'",  input$select_ver , "',",
+        "'",  values$name,       "',",
+        "'",  values$role,       "',",
+        "'",  cmnt,              "',",
+        "'",  cm_type,           "',",
+        "'",  TimeStamp(),       "'" ,
+        ")"
       )
     )
     values$cum_comment_submitted <- "yes"

--- a/Server/communityusage_metrics.R
+++ b/Server/communityusage_metrics.R
@@ -15,7 +15,7 @@ observe({
     if (input$select_pack != "Select") {
     
       # Load the columns into values$riskmetrics.
-      pkgs_in_db <- db_fun(paste0("SELECT cum_id FROM CommunityUsageMetrics"))
+      pkgs_in_db <- db_fun(paste0("SELECT DISTINCT cum_id FROM CommunityUsageMetrics"))
       
       if (input$select_pack %in% pkgs_in_db$cum_id &&
           !identical(pkgs_in_db$cum_id, character(0))) {
@@ -106,40 +106,46 @@ output$time_since_version_release <- renderInfoBox({
 output$no_of_downloads <- renderHighchart({
 
   if (values$riskmetrics_cum$no_of_downloads_last_year[1] != 0) {
-      hc <- highchart() %>%
-        hc_xAxis(categories = values$riskmetrics_cum$month) %>%
-        hc_xAxis(
-          title = list(text = "Months"),
-          
-          plotLines = map2(values$riskmetrics_cum$ver_release, values$riskmetrics_cum$position,
-                function(.x, .y)  list(label = list(text = .x), color = "#FF0000", width = 2, value = .y) )
-          
-        ) %>%
-        hc_add_series(
-          name = input$select_pack,
-          data = values$riskmetrics_cum$no_of_downloads,
-          color = "blue"
-        ) %>%
-        hc_yAxis(title = list(text = "Downloads")) %>%
-        hc_title(text = "NUMBER OF DOWNLOADS IN PREVIOUS 11 MONTHS") %>%
-        hc_subtitle(
-          text = paste(
-            "Total Number of Downloads :",
-            sum(values$riskmetrics_cum$no_of_downloads)
-          ),
-          align = "right",
-          style = list(color = "#2b908f", fontWeight = "bold")
-        ) %>%
-        hc_add_theme(hc_theme_elementary())
+    
+    package_ver <- gsub("'",'"',packageVersion(input$select_pack)) # get the installed version
+    fr_date <- values$riskmetrics_cum$month[[1]]
+    to_date <- values$riskmetrics_cum$month[[nrow(values$riskmetrics_cum)]]
+    
+    hc <- highchart() %>%
+      hc_xAxis(categories = values$riskmetrics_cum$month) %>%
+      hc_xAxis(
+        title = list(text = "Months"),
+        
+        plotLines = map2(values$riskmetrics_cum$ver_release, values$riskmetrics_cum$position,
+                         function(.x, .y)  list(label = list(text = .x), color = "#FF0000", width = 2, value = .y) )
+        
+      ) %>%
+      hc_add_series(
+        name = input$select_pack,
+        data = values$riskmetrics_cum$no_of_downloads,
+        color = "blue"
+      ) %>%
+      hc_yAxis(title = list(text = "Downloads")) %>%
+      hc_title(text = paste("Number of Downloads from", fr_date,"to", to_date, "for the package:",input$select_pack,"up to version",package_ver)) %>%
+      hc_subtitle(
+        text = paste(
+          "Total Number of Downloads :",
+          unique(values$riskmetrics_cum$no_of_downloads_last_year)
+        ),
+        align = "right",
+        style = list(color = "#2b908f", fontWeight = "bold")
+      ) %>%
+      hc_add_theme(hc_theme_elementary())
+    
     } else {
       hc <- highchart() %>%
         hc_xAxis(categories = NULL) %>%
         hc_xAxis(title = list(text = "Months")) %>%
         hc_add_series(name = input$select_pack, data = NULL) %>%
         hc_yAxis(title = list(text = "Downloads")) %>%
-        hc_title(text = "NUMBER OF DOWNLOADS IN PREVIOUS 11 MONTHS") %>%
+        hc_title(text = "NUMBER OF DOWNLOADS IN PREVIOUS MONTHS") %>%
         hc_subtitle(
-          text = paste("Number of Downloads in the 11 previous months are zero"),
+          text = paste("Number of Downloads in the previous months are zero"),
           style = list(color = "#f44336", fontWeight = "bold")
         ) %>%
         hc_add_theme(hc_theme_elementary())

--- a/setup.R
+++ b/setup.R
@@ -24,6 +24,8 @@ packages = c("shiny"
              ,"shinycssloaders"
              ,"rAmCharts"
              ,"devtools"
+             ,"versions"
+             ,"cranlogs"
 )
 
 ## load or install&load all required Packages.

--- a/setup.R
+++ b/setup.R
@@ -14,19 +14,20 @@ packages = c("shiny"
              ,"rvest"
              ,"xml2"
              ,"httr"
-             ,"desc"
              ,"dplyr"
+             ,"desc"
              ,"tools"
              ,"stringr"
-             ,"tidyverse"
              ,"loggit"
              ,"highcharter"
              ,"shinycssloaders"
              ,"rAmCharts"
              ,"devtools"
              ,"versions"
+             ,"purrr"
+             ,"rlang"
              ,"cranlogs"
-)
+)    
 
 ## load or install&load all required Packages.
 


### PR DESCRIPTION
This PR has **no dependencies** on any other PR
In a way, this relates to issue #54

- Added:  "versions" and  "cranlogs" to `setup.R`
- Replaced:  `metric_cum_Info_upload_to_DB()` in `dbupload.R`
   Note:  the version is derived from the installed version for now
   `package_ver <- gsub("'",'"',packageVersion(package_name)) # get the installed version`
- Replaced:  `output$no_of_downloads <- renderHighchart({` section of `communityusage_metrics.R`
   Again: the version is derived from the installed version for now.

Once the versioning PR is added, a couple of minor changes will need to be made to:
`uploadpackage.R`, `dbupload.R` and `communityusage_metrics.R`