### PR TITLE
Number of downloads using plotly

### DIFF
--- a/Reports/Report_doc.Rmd
+++ b/Reports/Report_doc.Rmd
@@ -71,6 +71,8 @@ comment_o <-
    
   time_since_first_release_info <- riskmetrics_cum$time_since_first_release[1] 
   time_since_version_release_info <-riskmetrics_cum$time_since_version_release[1]
+  no_of_downloads_last_year_info <-
+        riskmetrics_cum$no_of_downloads_last_year[1]
   
   riskmetrics_tm <-
     db_fun(
@@ -254,136 +256,32 @@ table_mm<-data.frame("User ID"=comment_mm$user_name,"Role"= comment_mm$user_role
 
 ```{r echo=FALSE}
 
-Metric<-c("Package Maturity","Version Maturity")
+Metric<-c("Package Maturity", "Version Maturity", "Download Count")
 
 Result<-c(
      if(time_since_first_release_info == -1){"NA"}
       else{time_since_first_release_info},
      if(time_since_version_release_info == -1){"NA"}
-      else{time_since_version_release_info}
+      else{time_since_version_release_info},
+     if(no_of_downloads_last_year_info == -1){"NA"}
+      else{formatC(no_of_downloads_last_year_info, format="f", big.mark=",", digits=0)}
 )
 
 Detail<-c(
      if(time_since_first_release_info == -1){"Metric is not applicable for this source of package"}
        else{"Months since first release."},
      if(time_since_version_release_info == -1){"Metric is not applicable for this source of package"}
-       else{"Months since version release."}
+       else{"Months since version release."},
+     if(no_of_downloads_last_year_info == -1){"Metric is not applicable for this source of package"}
+       else{"Downloads in Last Year."}
 )
 
 table_infobox_cum<-data.frame(Metric,Result,Detail)
 
 knitr::kable(table_infobox_cum, format='pandoc')
 
-if (riskmetrics_cum$no_of_downloads_last_year[1] != 0) {
-    hc <- highchart() %>%
-      hc_xAxis(categories = riskmetrics_cum$month) %>%
-      hc_xAxis(
-        title = list(text = "Months"),
-        plotLines = list(
-          list(
-            label = list(text = riskmetrics_cum$ver_release[1]),
-            color = "#FF0000",
-            width = 2,
-            value = riskmetrics_cum$position[1]
-          ),
-          list(
-            label = list(text = riskmetrics_cum$ver_release[2]),
-            color = "#FF0000",
-            width = 2,
-            value = riskmetrics_cum$position[2]
-          ),
-          list(
-            label = list(text = riskmetrics_cum$ver_release[3]),
-            color = "#FF0000",
-            width = 2,
-            value = riskmetrics_cum$position[3]
-          ),
-          list(
-            label = list(text = riskmetrics_cum$ver_release[4]),
-            color = "#FF0000",
-            width = 2,
-            value = riskmetrics_cum$position[4]
-          ),
-          list(
-            label = list(text = riskmetrics_cum$ver_release[5]),
-            color = "#FF0000",
-            width = 2,
-            value = riskmetrics_cum$position[5]
-          ),
-          list(
-            label = list(text = riskmetrics_cum$ver_release[6]),
-            color = "#FF0000",
-            width = 2,
-            value = riskmetrics_cum$position[6]
-          ),
-          list(
-            label = list(text = riskmetrics_cum$ver_release[7]),
-            color = "#FF0000",
-            width = 2,
-            value = riskmetrics_cum$position[7]
-          ),
-          list(
-            label = list(text = riskmetrics_cum$ver_release[8]),
-            color = "#FF0000",
-            width = 2,
-            value = riskmetrics_cum$position[8]
-          ),
-          list(
-            label = list(text = riskmetrics_cum$ver_release[9]),
-            color = "#FF0000",
-            width = 2,
-            value = riskmetrics_cum$position[9]
-          ),
-          list(
-            label = list(text = riskmetrics_cum$ver_release[10]),
-            color = "#FF0000",
-            width = 2,
-            value = riskmetrics_cum$position[10]
-          ),
-          list(
-            label = list(text = riskmetrics_cum$ver_release[11]),
-            color = "#FF0000",
-            width = 2,
-            value = riskmetrics_cum$position[11]
-          ),
-          list(
-            label = list(text = riskmetrics_cum$ver_release[12]),
-            color = "#FF0000",
-            width = 2,
-            value = riskmetrics_cum$position[12]
-          )
-        )
-      ) %>%
-      hc_add_series(
-        name = params$package,
-        data = riskmetrics_cum$no_of_downloads,
-        color = "blue"
-      ) %>%
-      hc_yAxis(title = list(text = "Downloads")) %>%
-      hc_title(text = "NUMBER OF DOWNLOADS IN PREVIOUS 11 MONTHS") %>%
-      hc_subtitle(
-        text = paste(
-          "Total Number of Downloads :",
-          sum(riskmetrics_cum$no_of_downloads)
-        ),
-        align = "right",
-        style = list(color = "#2b908f", fontWeight = "bold")
-      ) %>%
-      hc_add_theme(hc_theme_elementary())
-  } else{
-    hc <- highchart() %>%
-      hc_xAxis(categories = NULL) %>%
-      hc_xAxis(title = list(text = "Months")) %>%
-      hc_add_series(name = params$package, data = NULL) %>%
-      hc_yAxis(title = list(text = "Downloads")) %>%
-      hc_title(text = "NUMBER OF DOWNLOADS IN PREVIOUS 11 MONTHS") %>%
-      hc_subtitle(
-        text = paste("Number of Downloads in the 11 previous months are zero"),
-        style = list(color = "#f44336", fontWeight = "bold")
-      ) %>%
-      hc_add_theme(hc_theme_elementary())
-  }
-hc
+num_dwnlds_plot(data = riskmetrics_cum,
+                    input_select_pack = params$package)
 
 ```
 

--- a/Reports/Report_html.Rmd
+++ b/Reports/Report_html.Rmd
@@ -70,7 +70,9 @@ comment_o <-
   }
    
   time_since_first_release_info <- riskmetrics_cum$time_since_first_release[1] 
-  time_since_version_release_info <-riskmetrics_cum$time_since_version_release[1]
+  time_since_version_release_info <- riskmetrics_cum$time_since_version_release[1]
+  no_of_downloads_last_year_info <-
+        riskmetrics_cum$no_of_downloads_last_year[1]
   
   riskmetrics_tm <-
     db_fun(
@@ -383,118 +385,38 @@ comment_mm <- data.frame(comment_mm %>% map(rev))
     fill = TRUE
   )
   
-if (riskmetrics_cum$no_of_downloads_last_year[1] != 0) {
-      hc <- highchart() %>%
-        hc_xAxis(categories = riskmetrics_cum$month) %>%
-        hc_xAxis(
-          title = list(text = "Months"),
-          plotLines = list(
-            list(
-              label = list(text = riskmetrics_cum$ver_release[1]),
-              color = "#FF0000",
-              width = 2,
-              value = riskmetrics_cum$position[1]
-            ),
-            list(
-              label = list(text = riskmetrics_cum$ver_release[2]),
-              color = "#FF0000",
-              width = 2,
-              value = riskmetrics_cum$position[2]
-            ),
-            list(
-              label = list(text = riskmetrics_cum$ver_release[3]),
-              color = "#FF0000",
-              width = 2,
-              value = riskmetrics_cum$position[3]
-            ),
-            list(
-              label = list(text = riskmetrics_cum$ver_release[4]),
-              color = "#FF0000",
-              width = 2,
-              value = riskmetrics_cum$position[4]
-            ),
-            list(
-              label = list(text = riskmetrics_cum$ver_release[5]),
-              color = "#FF0000",
-              width = 2,
-              value = riskmetrics_cum$position[5]
-            ),
-            list(
-              label = list(text = riskmetrics_cum$ver_release[6]),
-              color = "#FF0000",
-              width = 2,
-              value = riskmetrics_cum$position[6]
-            ),
-            list(
-              label = list(text = riskmetrics_cum$ver_release[7]),
-              color = "#FF0000",
-              width = 2,
-              value = riskmetrics_cum$position[7]
-            ),
-            list(
-              label = list(text = riskmetrics_cum$ver_release[8]),
-              color = "#FF0000",
-              width = 2,
-              value = riskmetrics_cum$position[8]
-            ),
-            list(
-              label = list(text = riskmetrics_cum$ver_release[9]),
-              color = "#FF0000",
-              width = 2,
-              value = riskmetrics_cum$position[9]
-            ),
-            list(
-              label = list(text = riskmetrics_cum$ver_release[10]),
-              color = "#FF0000",
-              width = 2,
-              value = riskmetrics_cum$position[10]
-            ),
-            list(
-              label = list(text = riskmetrics_cum$ver_release[11]),
-              color = "#FF0000",
-              width = 2,
-              value = riskmetrics_cum$position[11]
-            ),
-            list(
-              label = list(text = riskmetrics_cum$ver_release[12]),
-              color = "#FF0000",
-              width = 2,
-              value = riskmetrics_cum$position[12]
-            )
-          )
-        ) %>%
-        hc_add_series(
-          name = params$package,
-          data = riskmetrics_cum$no_of_downloads,
-          color = "blue"
-        ) %>%
-        hc_yAxis(title = list(text = "Downloads")) %>%
-        hc_title(text = "NUMBER OF DOWNLOADS IN PREVIOUS 11 MONTHS") %>%
-        hc_subtitle(
-          text = paste(
-            "Total Number of Downloads :",
-            sum(riskmetrics_cum$no_of_downloads)
-          ),
-          align = "right",
-          style = list(color = "#2b908f", fontWeight = "bold")
-        ) %>%
-        hc_add_theme(hc_theme_elementary())
-      hc
-    } else{
-      hc <- highchart() %>%
-        hc_xAxis(categories = NULL) %>%
-        hc_xAxis(title = list(text = "Months")) %>%
-        hc_add_series(name = params$package, data = NULL) %>%
-        hc_yAxis(title = list(text = "Downloads")) %>%
-        hc_title(text = "NUMBER OF DOWNLOADS IN PREVIOUS 11 MONTHS") %>%
-        hc_subtitle(
-          text = paste("Number of Downloads in the 11 previous months are zero"),
-          style = list(color = "#f44336", fontWeight = "bold")
-        ) %>%
-        hc_add_theme(hc_theme_elementary())
-      hc
-    }
+  infoBox(
+    title = "Download Count",
+    formatC(no_of_downloads_last_year_info, format="f", big.mark=",", digits=0),
+    subtitle = ifelse(no_of_downloads_last_year_info != "NA", 
+                      "Downloads in Last Year",
+                      "Metric is not applicable for this source of package."),
+    icon = shiny::icon("signal"),
+    width = 3,
+    fill = TRUE
+  )
+  
 
+
+```
+
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+<br>
+
+```{r echo=FALSE}
+p <- num_dwnlds_plot(data = riskmetrics_cum,
+                    input_select_pack = params$package)
+tagList(p)
 ```
 
 ```{r echo=FALSE}

--- a/Server/communityusage_metrics.R
+++ b/Server/communityusage_metrics.R
@@ -149,7 +149,7 @@ output$no_of_downloads <-
 
     # how many months since the last release? + 1
     curr_mth <- plot_dat$month_date[nrow(plot_dat)]
-    rel_mths <- plot_dat$month_date[plot_dat$ver_release != 'NA']
+    rel_mths <- plot_dat$month_date[!(plot_dat$ver_release %in% c("",'NA'))]
     lst_rel_mth <- rel_mths[length(rel_mths)]
     mnths2_lst_rel <- mondf(lst_rel_mth, curr_mth) + ifelse(lst_rel_mth == curr_mth, 2, 1)
     
@@ -171,44 +171,75 @@ output$no_of_downloads <-
                                                ,'select2d', 'lasso2d', 'toggleSpikelines'
                                                # , 'toImage', 'resetScale2d', 'zoomIn2d', 'zoomOut2d','zoom2d', 'pan2d'
                      ))
-    fig <- fig %>% add_segments(x = ~if_else(ver_release != "NA", month_date, NA_Date_),
-                                xend = ~if_else(ver_release != "NA", month_date, NA_Date_),
-                                y = ~.98*min(no_of_downloads),
-                                yend = ~1.02*max(no_of_downloads),
-                                name = "Version Release",
-                                hoverinfo = "text",
-                                text = ~paste0('Version: ', ver_release, '<br>', month),
-                                line = list(color = "#FF0000")
-    )
-    fig <- fig %>% layout(
-      xaxis = list(
-        rangeselector = list(
-          buttons = list(
-            list(
-              count = 6,
-              label = "6 mo",
-              step = "month",
-              stepmode = "backward"),
-            list(
-              count = 1,
-              label = "1 yr",
-              step = "year",
-              stepmode = "backward"),
-            list(
-              count = 2,
-              label = "2 yr",
-              step = "year",
-              stepmode = "year"),
-            list(step = "all"),
-            list(count = mnths2_lst_rel,
-                 label = "Last Release",
-                 step = "month",
-                 stepmode = "backward"))),
-        
-        rangeslider = list(type = "date"))
-    )
+    # any versions?
+    any_ver_rel <- any(!(plot_dat$ver_release %in% c("","NA")))
+    if(any_ver_rel){
+      fig <- fig %>% add_segments(x = ~if_else(!(ver_release %in% c("","NA")), month_date, NA_Date_),
+                                  xend = ~if_else(!(ver_release %in% c("","NA")), month_date, NA_Date_),
+                                  y = ~.98*min(no_of_downloads),
+                                  yend = ~1.02*max(no_of_downloads),
+                                  name = "Version Release",
+                                  hoverinfo = "text",
+                                  text = ~paste0('Version: ', ver_release, '<br>', month),
+                                  line = list(color = "#FF0000")
+      )
+      fig <- fig %>% layout(
+        xaxis = list(
+          rangeselector = list(
+            buttons = list(
+              list(
+                count = 6,
+                label = "6 mo",
+                step = "month",
+                stepmode = "backward"),
+              list(
+                count = 1,
+                label = "1 yr",
+                step = "year",
+                stepmode = "backward"),
+              list(
+                count = 2,
+                label = "2 yr",
+                step = "year",
+                stepmode = "year"),
+              list(step = "all", label = "All"),
+              list(count = mnths2_lst_rel,
+                   label = "Last Release",
+                   step = "month",
+                   stepmode = "backward"))),
+          
+          rangeslider = list(type = "date"))
+      )
+    } else { # no 'Last Release' option
+      fig <- fig %>% layout(
+        xaxis = list(
+          rangeselector = list(
+            buttons = list(
+              list(
+                count = 6,
+                label = "6 mo",
+                step = "month",
+                stepmode = "backward"),
+              list(
+                count = 1,
+                label = "1 yr",
+                step = "year",
+                stepmode = "backward"),
+              list(
+                count = 2,
+                label = "2 yr",
+                step = "year",
+                stepmode = "year"),
+              list(step = "all", label = "All"))),
+          
+          rangeslider = list(type = "date"))
+      )
+    }
+    
     # reveal plot
     fig
+    
+    
     } else {
       stop("Plot for packages with 0 downloads in last year has not been set up yet")
       # hc <- highchart() %>%

--- a/Server/communityusage_metrics.R
+++ b/Server/communityusage_metrics.R
@@ -102,9 +102,10 @@ output$time_since_version_release <- renderInfoBox({
   
 })  # End of the time since version release render Output.
 
-output$no_of_downloads_data <- renderTable({
-  values$riskmetrics_cum
-})
+# For previewing data being plotted
+# output$no_of_downloads_data <- renderTable({
+#   values$riskmetrics_cum
+# })
 
 # 3. Render Output to show the highchart for number of downloads on the application.
 output$no_of_downloads <- 
@@ -143,8 +144,7 @@ output$no_of_downloads <-
              year = stringr::word(month, -1)) %>%
       left_join(swap) %>%
       mutate(month_date = as.Date(
-        paste("01", month_num, year, sep = "-")
-        , "%d-%m-%Y", origin = "1970-01-01")
+        paste("01", month_num, year, sep = "-"), "%d-%m-%Y")
       )
     
     fig <- plot_ly(plot_dat, x = ~month_date, y = ~no_of_downloads,
@@ -156,7 +156,8 @@ output$no_of_downloads <-
       layout(title = ~paste("NUMBER OF DOWNLOADS BY MONTH:", input$select_pack),
              showlegend = FALSE,
              yaxis = list(title = "Downloads"),
-             xaxis = list(title = "Month")
+             xaxis = list(title = "Month"),
+             margin = list(t = 80)
       ) %>%
       plotly::config(displaylogo = FALSE, 
                      modeBarButtonsToRemove= c('sendDataToCloud', 'hoverCompareCartesian','hoverClosestCartesian','autoScale2d'

--- a/Server/communityusage_metrics.R
+++ b/Server/communityusage_metrics.R
@@ -49,7 +49,7 @@ observe({
       values$time_since_version_release_info <-
         values$riskmetrics_cum$time_since_version_release[1]
       
-      # Load the data table column into reactive variable for time since version release.
+      # Load the data table column into reactive variable for num dwnlds in year
       values$no_of_downloads_last_year_info <-
         values$riskmetrics_cum$no_of_downloads_last_year[1]
       

--- a/Server/communityusage_metrics.R
+++ b/Server/communityusage_metrics.R
@@ -41,13 +41,17 @@ observe({
         }
       }
       
-      # Load the data table column into reactive variable for time sice first release.
+      # Load the data table column into reactive variable for time since first release.
       values$time_since_first_release_info <-
         values$riskmetrics_cum$time_since_first_release[1]
       
-      # Load the data table column into reactive variable for time sice version release.
+      # Load the data table column into reactive variable for time since version release.
       values$time_since_version_release_info <-
         values$riskmetrics_cum$time_since_version_release[1]
+      
+      # Load the data table column into reactive variable for time since version release.
+      values$no_of_downloads_last_year_info <-
+        values$riskmetrics_cum$no_of_downloads_last_year[1]
       
       runjs( "setTimeout(function(){ capturingSizeOfInfoBoxes(); }, 100);" )
       
@@ -102,10 +106,25 @@ output$time_since_version_release <- renderInfoBox({
   
 })  # End of the time since version release render Output.
 
-# For previewing data being plotted
-# output$no_of_downloads_data <- renderTable({
-#   values$riskmetrics_cum
-# })
+
+
+# 2.5 Render Output info box to show the number of downloads last year
+
+output$dwnlds_last_yr <- renderInfoBox({
+  req(values$no_of_downloads_last_year_info)
+  infoBox(
+    title = "Download Count",
+    formatC(values$no_of_downloads_last_year_info, format="f", big.mark=",", digits=0),
+    subtitle = ifelse(values$no_of_downloads_last_year_info != "NA",
+                      "Downloads in Last Year",
+                      "Metric is not applicable for this source of package."),
+    icon = shiny::icon("signal"),
+    width = 3,
+    fill = TRUE
+  )
+
+})  # End of the time since version release render Output.
+
 
 # 3. Render Output to show the highchart for number of downloads on the application.
 output$no_of_downloads <- 

--- a/Server/communityusage_metrics.R
+++ b/Server/communityusage_metrics.R
@@ -103,7 +103,9 @@ output$time_since_version_release <- renderInfoBox({
 })  # End of the time since version release render Output.
 
 # 3. Render Output to show the highchart for number of downloads on the application.
-output$no_of_downloads <- renderHighchart({
+output$no_of_downloads <- 
+  plotly::renderPlotly({
+  # renderHighchart({
 
   if (values$riskmetrics_cum$no_of_downloads_last_year[1] != 0) {
       hc <- highchart() %>%

--- a/Server/communityusage_metrics.R
+++ b/Server/communityusage_metrics.R
@@ -179,7 +179,7 @@ output$no_of_downloads <-
                    hoverinfo = "text",
                    text = ~paste0('# Dwnlds: ', formatC(no_of_downloads, format="f", big.mark=",", digits=0),
                                   '<br>', month)) %>%
-      layout(title = ~paste("NUMBER OF DOWNLOADS BY MONTH:", input$select_pack),
+      layout(title = ~paste("Number of Downloads by Month:", input$select_pack),
              showlegend = FALSE,
              yaxis = list(title = "Downloads"),
              xaxis = list(title = "Month"),

--- a/Server/communityusage_metrics.R
+++ b/Server/communityusage_metrics.R
@@ -123,172 +123,17 @@ output$dwnlds_last_yr <- renderInfoBox({
     fill = TRUE
   )
 
-})  # End of the time since version release render Output.
+})  # End 
 
 
-# 3. Render Output to show the highchart for number of downloads on the application.
+# 3. Render Output to show the plot for number of downloads on the application.
 output$no_of_downloads <- 
   plotly::renderPlotly({
-  # renderHighchart({
-
-  if (values$riskmetrics_cum$no_of_downloads_last_year[1] != 0) {
-      # hc <- highchart() %>%
-      #   hc_xAxis(categories = values$riskmetrics_cum$month) %>%
-      #   hc_xAxis(
-      #     title = list(text = "Months"),
-      #     
-      #     plotLines = map2(values$riskmetrics_cum$ver_release, values$riskmetrics_cum$position,
-      #           function(.x, .y)  list(label = list(text = .x), color = "#FF0000", width = 2, value = .y) )
-      #     
-      #   ) %>%
-      #   hc_add_series(
-      #     name = input$select_pack,
-      #     data = values$riskmetrics_cum$no_of_downloads,
-      #     color = "blue"
-      #   ) %>%
-      #   hc_yAxis(title = list(text = "Downloads")) %>%
-      #   hc_title(text = "NUMBER OF DOWNLOADS IN PREVIOUS 11 MONTHS") %>%
-      #   hc_subtitle(
-      #     text = paste(
-      #       "Total Number of Downloads :",
-      #       sum(values$riskmetrics_cum$no_of_downloads)
-      #     ),
-      #     align = "right", 
-      #     style = list(color = "#2b908f", fontWeight = "bold")
-      #   ) %>%
-      #   hc_add_theme(hc_theme_elementary())
-    swap <- data.frame(month_num = paste(1:12), month_name = month.name)
-    plot_dat <- values$riskmetrics_cum %>%
-      mutate(month_name = stringr::word(month),
-             year = stringr::word(month, -1)) %>%
-      left_join(swap) %>%
-      mutate(month_date = as.Date(
-        paste("01", month_num, year, sep = "-"), "%d-%m-%Y")
-      )
-
-    # how many months since the last release? + 1
-    curr_mth <- plot_dat$month_date[nrow(plot_dat)]
-    rel_mths <- plot_dat$month_date[!(plot_dat$ver_release %in% c("",'NA'))]
-    lst_rel_mth <- rel_mths[length(rel_mths)]
-    mnths2_lst_rel <- mondf(lst_rel_mth, curr_mth) + ifelse(lst_rel_mth == curr_mth, 2, 1)
-    
-    
-    fig <- plot_ly(plot_dat, x = ~month_date, y = ~no_of_downloads,
-                   name = "# Downloads", type = 'scatter', 
-                   mode = 'lines+markers', line = list(color = "blue"),
-                   hoverinfo = "text",
-                   text = ~paste0('# Dwnlds: ', formatC(no_of_downloads, format="f", big.mark=",", digits=0),
-                                  '<br>', month)) %>%
-      layout(title = ~paste("Number of Downloads by Month:", input$select_pack),
-             showlegend = FALSE,
-             yaxis = list(title = "Downloads"),
-             xaxis = list(title = "Month"),
-             margin = list(t = 80)
-      ) %>%
-      plotly::config(displaylogo = FALSE, 
-                     modeBarButtonsToRemove= c('sendDataToCloud', 'hoverCompareCartesian','hoverClosestCartesian','autoScale2d'
-                                               ,'select2d', 'lasso2d', 'toggleSpikelines'
-                                               # , 'toImage', 'resetScale2d', 'zoomIn2d', 'zoomOut2d','zoom2d', 'pan2d'
-                     ))
-    # any versions?
-    ver_dat <- plot_dat %>% filter(!(ver_release %in% c("","NA")))
-    any_ver_rel <- nrow(ver_dat) > 0
-    # any_ver_rel <- any(!(plot_dat$ver_release %in% c("","NA")))
-    if(any_ver_rel){
-      fig <- fig %>% 
-        add_segments(
-          x = ~if_else(!(ver_release %in% c("","NA")), month_date, NA_Date_),
-          xend = ~if_else(!(ver_release %in% c("","NA")), month_date, NA_Date_),
-          y = ~.98*min(no_of_downloads),
-          yend = ~1.02*max(no_of_downloads),
-          name = "Version Release",
-          hoverinfo = "text",
-          text = ~paste0('Version ', ver_release, '<br>', month),
-          line = list(color = "#FF0000")
-        ) %>% 
-        add_annotations(
-          yref = 'paper', 
-          xref = "x", 
-          y = .93, 
-          x = ver_dat$month_date,
-          xanchor = 'left',
-          showarrow = F,
-          textangle = 90,
-          font = list(size = 14, color = '#000000'),
-          text = ver_dat$ver_release
-        )
-      fig <- fig %>% layout(
-        xaxis = list(
-          rangeselector = list(
-            buttons = list(
-              list(
-                count = 6,
-                label = "6 mo",
-                step = "month",
-                stepmode = "backward"),
-              list(
-                count = 1,
-                label = "1 yr",
-                step = "year",
-                stepmode = "backward"),
-              list(
-                count = 2,
-                label = "2 yr",
-                step = "year",
-                stepmode = "year"),
-              list(step = "all", label = "All"),
-              list(count = mnths2_lst_rel,
-                   label = "Last Release",
-                   step = "month",
-                   stepmode = "backward"))),
-          
-          rangeslider = list(type = "date"))
-      )
-    } else { # no 'Last Release' option
-      fig <- fig %>% layout(
-        xaxis = list(
-          rangeselector = list(
-            buttons = list(
-              list(
-                count = 6,
-                label = "6 mo",
-                step = "month",
-                stepmode = "backward"),
-              list(
-                count = 1,
-                label = "1 yr",
-                step = "year",
-                stepmode = "backward"),
-              list(
-                count = 2,
-                label = "2 yr",
-                step = "year",
-                stepmode = "year"),
-              list(step = "all", label = "All"))),
-          
-          rangeslider = list(type = "date"))
-      )
-    }
-    
-    # reveal plot
-    fig
-    
-    
-    } else {
-      stop("Plot for packages with 0 downloads in last year has not been set up yet")
-      # hc <- highchart() %>%
-      #   hc_xAxis(categories = NULL) %>%
-      #   hc_xAxis(title = list(text = "Months")) %>%
-      #   hc_add_series(name = input$select_pack, data = NULL) %>%
-      #   hc_yAxis(title = list(text = "Downloads")) %>%
-      #   hc_title(text = "NUMBER OF DOWNLOADS IN PREVIOUS 11 MONTHS") %>%
-      #   hc_subtitle(
-      #     text = paste("Number of Downloads in the 11 previous months are zero"),
-      #     style = list(color = "#f44336", fontWeight = "bold")
-      #   ) %>%
-      #   hc_add_theme(hc_theme_elementary())
-    }
+    num_dwnlds_plot(data = values$riskmetrics_cum,
+                    input_select_pack = input$select_pack)
 })
+
+
 
 # 4. Render output to show the comments.
 

--- a/Server/communityusage_metrics.R
+++ b/Server/communityusage_metrics.R
@@ -146,6 +146,13 @@ output$no_of_downloads <-
       mutate(month_date = as.Date(
         paste("01", month_num, year, sep = "-"), "%d-%m-%Y")
       )
+
+    # how many months since the last release? + 1
+    curr_mth <- plot_dat$month_date[nrow(plot_dat)]
+    rel_mths <- plot_dat$month_date[plot_dat$ver_release != 'NA']
+    lst_rel_mth <- rel_mths[length(rel_mths)]
+    mnths2_lst_rel <- mondf(lst_rel_mth, curr_mth) + ifelse(lst_rel_mth == curr_mth, 2, 1)
+    
     
     fig <- plot_ly(plot_dat, x = ~month_date, y = ~no_of_downloads,
                    name = "# Downloads", type = 'scatter', 
@@ -178,11 +185,6 @@ output$no_of_downloads <-
         rangeselector = list(
           buttons = list(
             list(
-              count = 3,
-              label = "3 mo",
-              step = "month",
-              stepmode = "backward"),
-            list(
               count = 6,
               label = "6 mo",
               step = "month",
@@ -197,7 +199,11 @@ output$no_of_downloads <-
               label = "2 yr",
               step = "year",
               stepmode = "year"),
-            list(step = "all"))),
+            list(step = "all"),
+            list(count = mnths2_lst_rel,
+                 label = "Last Release",
+                 step = "month",
+                 stepmode = "backward"))),
         
         rangeslider = list(type = "date"))
     )

--- a/Server/communityusage_metrics.R
+++ b/Server/communityusage_metrics.R
@@ -191,17 +191,32 @@ output$no_of_downloads <-
                                                # , 'toImage', 'resetScale2d', 'zoomIn2d', 'zoomOut2d','zoom2d', 'pan2d'
                      ))
     # any versions?
-    any_ver_rel <- any(!(plot_dat$ver_release %in% c("","NA")))
+    ver_dat <- plot_dat %>% filter(!(ver_release %in% c("","NA")))
+    any_ver_rel <- nrow(ver_dat) > 0
+    # any_ver_rel <- any(!(plot_dat$ver_release %in% c("","NA")))
     if(any_ver_rel){
-      fig <- fig %>% add_segments(x = ~if_else(!(ver_release %in% c("","NA")), month_date, NA_Date_),
-                                  xend = ~if_else(!(ver_release %in% c("","NA")), month_date, NA_Date_),
-                                  y = ~.98*min(no_of_downloads),
-                                  yend = ~1.02*max(no_of_downloads),
-                                  name = "Version Release",
-                                  hoverinfo = "text",
-                                  text = ~paste0('Version: ', ver_release, '<br>', month),
-                                  line = list(color = "#FF0000")
-      )
+      fig <- fig %>% 
+        add_segments(
+          x = ~if_else(!(ver_release %in% c("","NA")), month_date, NA_Date_),
+          xend = ~if_else(!(ver_release %in% c("","NA")), month_date, NA_Date_),
+          y = ~.98*min(no_of_downloads),
+          yend = ~1.02*max(no_of_downloads),
+          name = "Version Release",
+          hoverinfo = "text",
+          text = ~paste0('Version ', ver_release, '<br>', month),
+          line = list(color = "#FF0000")
+        ) %>% 
+        add_annotations(
+          yref = 'paper', 
+          xref = "x", 
+          y = .93, 
+          x = ver_dat$month_date,
+          xanchor = 'left',
+          showarrow = F,
+          textangle = 90,
+          font = list(size = 14, color = '#000000'),
+          text = ver_dat$ver_release
+        )
       fig <- fig %>% layout(
         xaxis = list(
           rangeselector = list(

--- a/Server/cum_report.R
+++ b/Server/cum_report.R
@@ -47,6 +47,10 @@ observe({
       values$time_since_version_release_info <-
         values$riskmetrics_cum$time_since_version_release[1]
       
+      # Load the data table column into reactive variable for num dwnlds in year
+      values$no_of_downloads_last_year_info <-
+        values$riskmetrics_cum$no_of_downloads_last_year[1]
+      
       runjs( "setTimeout(function(){ capturingSizeOfInfoBoxes(); }, 100);" )
       
       req(values$riskmetrics_cum)

--- a/Server/cum_report.R
+++ b/Server/cum_report.R
@@ -94,121 +94,32 @@ output$time_since_version_release1 <- renderInfoBox({
   
 })  # End of the time since version release render Output.
 
-# 3. Render Output to show the highchart for number of downloads on the application.
-output$no_of_downloads1 <- renderHighchart({
-  if (values$riskmetrics_cum$no_of_downloads_last_year[1] != 0) {
-    hc <- highchart() %>%
-      hc_xAxis(categories = values$riskmetrics_cum$month) %>%
-      hc_xAxis(
-        title = list(text = "Months"),
-        plotLines = list(
-          list(
-            label = list(text = values$riskmetrics_cum$ver_release[1]),
-            color = "#FF0000",
-            width = 2,
-            value = values$riskmetrics_cum$position[1]
-          ),
-          list(
-            label = list(text = values$riskmetrics_cum$ver_release[2]),
-            color = "#FF0000",
-            width = 2,
-            value = values$riskmetrics_cum$position[2]
-          ),
-          list(
-            label = list(text = values$riskmetrics_cum$ver_release[3]),
-            color = "#FF0000",
-            width = 2,
-            value = values$riskmetrics_cum$position[3]
-          ),
-          list(
-            label = list(text = values$riskmetrics_cum$ver_release[4]),
-            color = "#FF0000",
-            width = 2,
-            value = values$riskmetrics_cum$position[4]
-          ),
-          list(
-            label = list(text = values$riskmetrics_cum$ver_release[5]),
-            color = "#FF0000",
-            width = 2,
-            value = values$riskmetrics_cum$position[5]
-          ),
-          list(
-            label = list(text = values$riskmetrics_cum$ver_release[6]),
-            color = "#FF0000",
-            width = 2,
-            value = values$riskmetrics_cum$position[6]
-          ),
-          list(
-            label = list(text = values$riskmetrics_cum$ver_release[7]),
-            color = "#FF0000",
-            width = 2,
-            value = values$riskmetrics_cum$position[7]
-          ),
-          list(
-            label = list(text = values$riskmetrics_cum$ver_release[8]),
-            color = "#FF0000",
-            width = 2,
-            value = values$riskmetrics_cum$position[8]
-          ),
-          list(
-            label = list(text = values$riskmetrics_cum$ver_release[9]),
-            color = "#FF0000",
-            width = 2,
-            value = values$riskmetrics_cum$position[9]
-          ),
-          list(
-            label = list(text = values$riskmetrics_cum$ver_release[10]),
-            color = "#FF0000",
-            width = 2,
-            value = values$riskmetrics_cum$position[10]
-          ),
-          list(
-            label = list(text = values$riskmetrics_cum$ver_release[11]),
-            color = "#FF0000",
-            width = 2,
-            value = values$riskmetrics_cum$position[11]
-          ),
-          list(
-            label = list(text = values$riskmetrics_cum$ver_release[12]),
-            color = "#FF0000",
-            width = 2,
-            value = values$riskmetrics_cum$position[12]
-          )
-        )
-      ) %>%
-      hc_add_series(
-        name = input$select_pack,
-        data = values$riskmetrics_cum$no_of_downloads,
-        color = "blue"
-      ) %>%
-      hc_yAxis(title = list(text = "Downloads")) %>%
-      hc_title(text = "NUMBER OF DOWNLOADS IN PREVIOUS 11 MONTHS") %>%
-      hc_subtitle(
-        text = paste(
-          "Total Number of Downloads :",
-          sum(values$riskmetrics_cum$no_of_downloads)
-        ),
-        align = "right",
-        style = list(color = "#2b908f", fontWeight = "bold")
-      ) %>%
-      hc_add_theme(hc_theme_elementary())
-  } else {
-    hc <- highchart() %>%
-      hc_xAxis(categories = NULL) %>%
-      hc_xAxis(title = list(text = "Months")) %>%
-      hc_add_series(name = input$select_pack, data = NULL) %>%
-      hc_yAxis(title = list(text = "Downloads")) %>%
-      hc_title(text = "NUMBER OF DOWNLOADS IN PREVIOUS 11 MONTHS") %>%
-      hc_subtitle(
-        text = paste("Number of Downloads in the 11 previous months are zero"),
-        style = list(color = "#f44336", fontWeight = "bold")
-      ) %>%
-      hc_add_theme(hc_theme_elementary())
-  }
-})
+# 2.5 Render Output info box to show the number of downloads last year
+
+output$dwnlds_last_yr1 <- renderInfoBox({
+  req(values$no_of_downloads_last_year_info)
+  infoBox(
+    title = "Download Count",
+    formatC(values$no_of_downloads_last_year_info, format="f", big.mark=",", digits=0),
+    subtitle = ifelse(values$no_of_downloads_last_year_info != "NA",
+                      "Downloads in Last Year",
+                      "Metric is not applicable for this source of package."),
+    icon = shiny::icon("signal"),
+    width = 3,
+    fill = TRUE
+  )
+  
+})  # End 
+
+# 3. Render Output to show the plot for number of downloads on the application.
+output$no_of_downloads1 <- 
+  plotly::renderPlotly({
+    num_dwnlds_plot(data = values$riskmetrics_cum,
+                    input_select_pack = input$select_pack)
+  })
+  
 
 # 4. Render output to show the comments.
-
 output$cum_commented1 <- renderText({
   if (values$cum_comment_submitted == "yes" ||
       values$cum_comment_submitted == "no") {

--- a/UI/communityusage_metrics.R
+++ b/UI/communityusage_metrics.R
@@ -35,7 +35,8 @@ output$community_usage_metrics <- renderUI({
           column(width = 2, )
         ),
         
-        fluidRow(tableOutput("no_of_downloads_data")),
+        # For previewing data being plotted
+        # fluidRow(tableOutput("no_of_downloads_data")),
         
         fluidRow(
           class = "c_u_m_row_comments_box",

--- a/UI/communityusage_metrics.R
+++ b/UI/communityusage_metrics.R
@@ -21,8 +21,9 @@ output$community_usage_metrics <- renderUI({
         class = "c_u_m_row_main",
         fluidRow(
           class = "c_u_m_row_1",
-          infoBoxOutput("time_since_first_release", width = 5),  # Info box to show the time since First release.
-          infoBoxOutput("time_since_version_release", width = 5)  # Info box to show the time since version release.
+          infoBoxOutput("time_since_first_release", width = 4),  # Info box to show the time since First release.
+          infoBoxOutput("time_since_version_release", width = 4),  # Info box to show the time since version release.
+          infoBoxOutput("dwnlds_last_yr", width = 4)  # Info box to show the total # of Downloads in the last year.
         ),
         fluidRow(
           class = "c_u_m_row_graph",
@@ -34,9 +35,6 @@ output$community_usage_metrics <- renderUI({
                  ),
           column(width = 2, )
         ),
-        
-        # For previewing data being plotted
-        # fluidRow(tableOutput("no_of_downloads_data")),
         
         fluidRow(
           class = "c_u_m_row_comments_box",

--- a/UI/communityusage_metrics.R
+++ b/UI/communityusage_metrics.R
@@ -31,7 +31,6 @@ output$community_usage_metrics <- renderUI({
           column(width = 10,
                  class = "w-90",
                  plotly::plotlyOutput("no_of_downloads")
-                 # highchartOutput("no_of_downloads")
                  ),
           column(width = 1, )
         ),

--- a/UI/communityusage_metrics.R
+++ b/UI/communityusage_metrics.R
@@ -29,7 +29,9 @@ output$community_usage_metrics <- renderUI({
           column(width = 2, ),
           column(width = 8,
                  class = "w-90",
-                 highchartOutput("no_of_downloads")),
+                 plotly::plotlyOutput("no_of_downloads")
+                 # highchartOutput("no_of_downloads")
+                 ),
           column(width = 2, )
         ),
         

--- a/UI/communityusage_metrics.R
+++ b/UI/communityusage_metrics.R
@@ -35,6 +35,8 @@ output$community_usage_metrics <- renderUI({
           column(width = 2, )
         ),
         
+        fluidRow(tableOutput("no_of_downloads_data")),
+        
         fluidRow(
           class = "c_u_m_row_comments_box",
           column(

--- a/UI/communityusage_metrics.R
+++ b/UI/communityusage_metrics.R
@@ -27,13 +27,13 @@ output$community_usage_metrics <- renderUI({
         ),
         fluidRow(
           class = "c_u_m_row_graph",
-          column(width = 2, ),
-          column(width = 8,
+          column(width = 1, ),
+          column(width = 10,
                  class = "w-90",
                  plotly::plotlyOutput("no_of_downloads")
                  # highchartOutput("no_of_downloads")
                  ),
-          column(width = 2, )
+          column(width = 1, )
         ),
         
         fluidRow(

--- a/UI/cum_report.R
+++ b/UI/cum_report.R
@@ -15,15 +15,18 @@ fluidRow(
   fluidRow(
     class = "c_u_m_row_1",
     infoBoxOutput("time_since_first_release1", width = 5),  # Info box to show the time since First release.
-    infoBoxOutput("time_since_version_release1", width = 5)  # Info box to show the time since version release.
+    infoBoxOutput("time_since_version_release1", width = 5),  # Info box to show the time since version release.
+    infoBoxOutput("dwnlds_last_yr1", width = 4)  # Info box to show the total # of Downloads in the last year.
   ),
   fluidRow(
     class = "c_u_m_row_graph",
-    column(width = 2, ),
-    column(width = 8,
+    column(width = 1, ),
+    column(width = 10,
            class = "w-90",
-           highchartOutput("no_of_downloads1")),
-    column(width = 2, )
+           plotly::plotlyOutput("no_of_downloads1")
+           # highchartOutput("no_of_downloads1")
+           ),
+    column(width = 1, )
   ),
   fluidRow(
     class = "c_u_m_row_comments",

--- a/UI/cum_report.R
+++ b/UI/cum_report.R
@@ -14,8 +14,8 @@ fluidRow(
   h3(tags$b("Community Usage Metrics"), class = "text-left"),
   fluidRow(
     class = "c_u_m_row_1",
-    infoBoxOutput("time_since_first_release1", width = 5),  # Info box to show the time since First release.
-    infoBoxOutput("time_since_version_release1", width = 5),  # Info box to show the time since version release.
+    infoBoxOutput("time_since_first_release1", width = 4),  # Info box to show the time since First release.
+    infoBoxOutput("time_since_version_release1", width = 4),  # Info box to show the time since version release.
     infoBoxOutput("dwnlds_last_yr1", width = 4)  # Info box to show the total # of Downloads in the last year.
   ),
   fluidRow(
@@ -24,7 +24,6 @@ fluidRow(
     column(width = 10,
            class = "w-90",
            plotly::plotlyOutput("no_of_downloads1")
-           # highchartOutput("no_of_downloads1")
            ),
     column(width = 1, )
   ),

--- a/Utils/cum_utils.R
+++ b/Utils/cum_utils.R
@@ -139,4 +139,4 @@ num_dwnlds_plot <- function(data = values$riskmetrics_cum,
   fig
 }
 # test output
-num_dwnlds_plot(data = values$riskmetrics_cum, input_select_pack = "dplyr")
+# num_dwnlds_plot(data = values$riskmetrics_cum, input_select_pack = "dplyr")

--- a/Utils/cum_utils.R
+++ b/Utils/cum_utils.R
@@ -1,0 +1,141 @@
+#####################################################################################################################
+# cum_utils.R - UI and Server utility functions for the community usage portion of the app
+# Author: Aaron Clark
+# Date: Dec 2nd, 2020
+# License: MIT License
+#####################################################################################################################
+
+
+# turn a date into a 'monthnumber' relative to an origin
+monnb <- function(d) { 
+  lt <- as.POSIXlt(as.Date(d, origin="1900-01-01"))
+  lt$year*12 + lt$mon
+} 
+
+# compute a month difference as a difference between two monnb's
+mondf <- function(d1, d2) { monnb(d2) - monnb(d1) }
+
+num_dwnlds_plot <- function(data = values$riskmetrics_cum, 
+                            input_select_pack
+                            ){
+  
+  swap <- data.frame(month_num = paste(1:12), month_name = month.name)
+  plot_dat <- data %>%
+    mutate(month_name = stringr::word(month),
+           year = stringr::word(month, -1)) %>%
+    left_join(swap) %>%
+    mutate(month_date = as.Date(
+      paste("01", month_num, year, sep = "-"), "%d-%m-%Y")
+    )
+  
+  # how many months since the last release? + 1
+  curr_mth <- plot_dat$month_date[nrow(plot_dat)]
+  rel_mths <- plot_dat$month_date[!(plot_dat$ver_release %in% c("",'NA'))]
+  lst_rel_mth <- rel_mths[length(rel_mths)]
+  mnths2_lst_rel <- mondf(lst_rel_mth, curr_mth) + ifelse(lst_rel_mth == curr_mth, 2, 1)
+  
+  
+  fig <- plot_ly(plot_dat, x = ~month_date, y = ~no_of_downloads,
+                 name = "# Downloads", type = 'scatter', 
+                 mode = 'lines+markers', line = list(color = "blue"),
+                 hoverinfo = "text",
+                 text = ~paste0('# Dwnlds: ', formatC(no_of_downloads, format="f", big.mark=",", digits=0),
+                                '<br>', month)) %>%
+    layout(title = ~paste(ifelse(!(data$no_of_downloads_last_year[1] %in% c(0, NA_integer_)),
+                                 "Number of Downloads by Month:", "Zero Downloads for"),
+                          input_select_pack),
+           showlegend = FALSE,
+           yaxis = list(title = "Downloads"),
+           xaxis = list(title = "Month"),
+           margin = list(t = 80)
+    ) %>%
+    plotly::config(displaylogo = FALSE, 
+                   modeBarButtonsToRemove= c('sendDataToCloud', 'hoverCompareCartesian','hoverClosestCartesian','autoScale2d'
+                                             ,'select2d', 'lasso2d', 'toggleSpikelines'
+                                             # , 'toImage', 'resetScale2d', 'zoomIn2d', 'zoomOut2d','zoom2d', 'pan2d'
+                   ))
+  # any versions?
+  ver_dat <- plot_dat %>% filter(!(ver_release %in% c("","NA")))
+  any_ver_rel <- nrow(ver_dat) > 0
+  # any_ver_rel <- any(!(plot_dat$ver_release %in% c("","NA")))
+  if(any_ver_rel){
+    fig <- fig %>% 
+      add_segments(
+        x = ~if_else(!(ver_release %in% c("","NA")), month_date, NA_Date_),
+        xend = ~if_else(!(ver_release %in% c("","NA")), month_date, NA_Date_),
+        y = ~.98*min(no_of_downloads),
+        yend = ~1.02*max(no_of_downloads),
+        name = "Version Release",
+        hoverinfo = "text",
+        text = ~paste0('Version ', ver_release, '<br>', month),
+        line = list(color = "#FF0000")
+      ) %>% 
+      add_annotations(
+        yref = 'paper', 
+        xref = "x", 
+        y = .93, 
+        x = ver_dat$month_date,
+        xanchor = 'left',
+        showarrow = F,
+        textangle = 90,
+        font = list(size = 14, color = '#000000'),
+        text = ver_dat$ver_release
+      )
+    fig <- fig %>% layout(
+      xaxis = list(
+        rangeselector = list(
+          buttons = list(
+            list(
+              count = 6,
+              label = "6 mo",
+              step = "month",
+              stepmode = "backward"),
+            list(
+              count = 1,
+              label = "1 yr",
+              step = "year",
+              stepmode = "backward"),
+            list(
+              count = 2,
+              label = "2 yr",
+              step = "year",
+              stepmode = "year"),
+            list(step = "all", label = "All"),
+            list(count = mnths2_lst_rel,
+                 label = "Last Release",
+                 step = "month",
+                 stepmode = "backward"))),
+        
+        rangeslider = list(type = "date"))
+    )
+  } else { # no 'Last Release' option
+    fig <- fig %>% layout(
+      xaxis = list(
+        rangeselector = list(
+          buttons = list(
+            list(
+              count = 6,
+              label = "6 mo",
+              step = "month",
+              stepmode = "backward"),
+            list(
+              count = 1,
+              label = "1 yr",
+              step = "year",
+              stepmode = "backward"),
+            list(
+              count = 2,
+              label = "2 yr",
+              step = "year",
+              stepmode = "year"),
+            list(step = "all", label = "All"))),
+        
+        rangeslider = list(type = "date"))
+    )
+  }
+  
+  # reveal plot
+  fig
+}
+# test output
+# num_dwnlds_plot(data = values$riskmetrics_cum, input_select_pack = "dplyr")

--- a/Utils/cum_utils.R
+++ b/Utils/cum_utils.R
@@ -1,9 +1,10 @@
-#####################################################################################################################
-# cum_utils.R - UI and Server utility functions for the community usage portion of the app
+#################################################################################
+# cum_utils.R - UI and Server utility functions for the community usage metric
+# portion of the app
 # Author: Aaron Clark
 # Date: Dec 2nd, 2020
 # License: MIT License
-#####################################################################################################################
+#################################################################################
 
 
 # turn a date into a 'monthnumber' relative to an origin

--- a/Utils/cum_utils.R
+++ b/Utils/cum_utils.R
@@ -24,7 +24,7 @@ num_dwnlds_plot <- function(data = values$riskmetrics_cum,
   plot_dat <- data %>%
     mutate(month_name = stringr::word(month),
            year = stringr::word(month, -1)) %>%
-    left_join(swap) %>%
+    left_join(swap, by = "month_name") %>%
     mutate(month_date = as.Date(
       paste("01", month_num, year, sep = "-"), "%d-%m-%Y")
     )
@@ -139,4 +139,4 @@ num_dwnlds_plot <- function(data = values$riskmetrics_cum,
   fig
 }
 # test output
-# num_dwnlds_plot(data = values$riskmetrics_cum, input_select_pack = "dplyr")
+num_dwnlds_plot(data = values$riskmetrics_cum, input_select_pack = "dplyr")

--- a/Utils/utils.R
+++ b/Utils/utils.R
@@ -87,11 +87,3 @@ GetUserName <- function() {
   
   return(x)
 }
-
-# turn a date into a 'monthnumber' relative to an origin
-monnb <- function(d) { 
-  lt <- as.POSIXlt(as.Date(d, origin="1900-01-01"))
-  lt$year*12 + lt$mon
-} 
-# compute a month difference as a difference between two monnb's
-mondf <- function(d1, d2) { monnb(d2) - monnb(d1) }

--- a/Utils/utils.R
+++ b/Utils/utils.R
@@ -87,3 +87,11 @@ GetUserName <- function() {
   
   return(x)
 }
+
+# turn a date into a 'monthnumber' relative to an origin
+monnb <- function(d) { 
+  lt <- as.POSIXlt(as.Date(d, origin="1900-01-01"))
+  lt$year*12 + lt$mon
+} 
+# compute a month difference as a difference between two monnb's
+mondf <- function(d1, d2) { monnb(d2) - monnb(d1) }

--- a/app.R
+++ b/app.R
@@ -13,6 +13,7 @@ source("global.R")
 source(file.path("Modules", "dbupload.R"))
 source(file.path("Modules", "file_upload_error_handling.R"))
 source(file.path("Utils", "utils.R"))
+source(file.path("Utils", "cum_utils.R"))
 
 # Create db if it doesn't exist.
 if(!file.exists(db_name)) create_db()

--- a/global.R
+++ b/global.R
@@ -22,6 +22,7 @@ packages = c("shiny"
              ,"shinycssloaders"
              ,"rAmCharts"
              ,"devtools"
+             ,"plotly"
 )
 
 # Install and load required packages.
@@ -70,4 +71,5 @@ if(!require(riskmetric)){
 # library(shinycssloaders)
 # library(rAmCharts)
 # library(devtools)
+# library(plotly)
 # library(riskmetric) # devtools::install_github("pharmaR/riskmetric")

--- a/global.R
+++ b/global.R
@@ -18,7 +18,6 @@ packages = c("shiny"
              ,"stringr"
              ,"tidyverse"
              ,"loggit"
-             ,"highcharter"
              ,"shinycssloaders"
              ,"rAmCharts"
              ,"devtools"
@@ -67,7 +66,6 @@ if(!require(riskmetric)){
 # library(stringr)
 # library(tidyverse)
 # library(loggit)
-# library(highcharter)
 # library(shinycssloaders)
 # library(rAmCharts)
 # library(devtools)


### PR DESCRIPTION
Fixes #74.

PR creates a more interactive plot for users to quickly and easily choose the best x-axis timeline for viewing their package download history. Prior to writing any code, the plot used the highcharter package and looked something like this:

![image](https://user-images.githubusercontent.com/17878953/100911907-d308a100-349d-11eb-9e89-512eb8f5e0c6.png)

This PR's changelog/ to-do list:

- [x] Replace highcharter() with more interactive plotly() object with range slider/ selector layout

- [x] Create `Last Release` button & remove `3 mo` timeline button

- [x] get vertical annotations on version release lines

- [x] Move all time number of downloads into a new info box, not as subtitle on graph

- [x] functionalize/ modularize plot so it can be quickly replicated in cum_report.R, plus both .docx and .html rmarkdown reports

The final plot looks like this:
![image](https://user-images.githubusercontent.com/17878953/100912233-32ff4780-349e-11eb-9e63-dcc6c35489c5.png)
