### PR TITLE
Clean DB Dashboard's Excel Output

### DIFF
--- a/Server/db_dash_screen.R
+++ b/Server/db_dash_screen.R
@@ -9,10 +9,8 @@
 output$db_pkgs <- DT::renderDataTable({
   values$db_pkg_overview <- db_fun(
     paste0(
-      "SELECT case when package = '",
-      input$select_pack,
-      "' then 1 else 0 end as Selected
-      , pi.package
+      "SELECT 
+       pi.package
       , pi.version
       , pi.score
       , pi.decision
@@ -33,18 +31,18 @@ output$db_pkgs <- DT::renderDataTable({
     values$db_pkg_overview,
     selection = list(mode = 'multiple'),
     extensions = "Buttons",
-    colnames = c("Selected", "Package", "Version",
+    colnames = c("Package", "Version",
                  "Score", "Decision", "Last Comment"),
     options = list(
       dom = 'Blftpr',
       pageLength = 10,
       lengthMenu = list(c(10, 50, 100, -1), c('15', '50', '100', "All")),
       columnDefs = list(
-        list(targets = 1, visible = FALSE),
         list(className = 'dt-center')
       ),
       buttons = list(list(
-        extend = "excel", 
+        extend = "excel",
+        title = "R Package Risk Assessment App: Package Upload History",
         filename = paste(
           sep = "_", 
           "RiskAsses_PkgDB_Dwnld",

--- a/UI/db_dash_screen.R
+++ b/UI/db_dash_screen.R
@@ -21,7 +21,7 @@ output$screen <- renderUI({
       column(
         align = "center",
         width = 8,
-        tags$h2("History of Packages Reviewed",
+        tags$h2("Package Upload History",
                 class = "card-title text-center txt-color font-weight-bold"),
         tags$hr(class = "bg-color"),
         id = "db_dash_screen",


### PR DESCRIPTION
**Changelog:**

- [x] Removed initially invisible 'Selected' column from `Package Upload History`'s excel download artifact

- [x] cleans up title/ header in the same artifact

- [x] Renames db_dash content from "History of Packages Reviewed" to "Package Upload History" since it is more accurate.

    ![image](https://user-images.githubusercontent.com/17878953/100664405-8bf7a000-3325-11eb-8014-9865efc3d801.png)
