### PR TITLE
Various fixes

### DIFF
--- a/Modules/dbupload.R
+++ b/Modules/dbupload.R
@@ -151,17 +151,15 @@ genInfo_upload_to_DB <- function(package_name, ver, title, desc, auth, main, lis
 
 metric_mm_tm_Info_upload_to_DB <- function(package_name){
   
-  package_riskmetric1 <<-
-    pkg_ref(package_name) %>%
-    as_tibble() %>%
-    pkg_assess() %>%
-    pkg_score() %>%
-    mutate(risk = summarize_scores(.))
-  
   package_riskmetric2 <<-
     pkg_ref(package_name) %>%
     as_tibble() %>%
     pkg_assess()
+  
+  package_riskmetric1 <<-
+    package_riskmetric2 %>%
+    pkg_score() %>%
+    mutate(risk = summarize_scores(.))
   
   package_riskmetric1$bugs_status <- package_riskmetric1$bugs_status*100
   package_riskmetric1$export_help <- package_riskmetric1$export_help*100

--- a/Modules/dbupload.R
+++ b/Modules/dbupload.R
@@ -151,39 +151,39 @@ genInfo_upload_to_DB <- function(package_name, ver, title, desc, auth, main, lis
 
 metric_mm_tm_Info_upload_to_DB <- function(package_name){
   
-  package_riskmetric2 <<-
+  riskmetric_assess <-
     pkg_ref(package_name) %>%
     as_tibble() %>%
     pkg_assess()
   
-  package_riskmetric1 <<-
-    package_riskmetric2 %>%
+  riskmetric_score <-
+    riskmetric_assess %>%
     pkg_score() %>%
     mutate(risk = summarize_scores(.))
   
-  package_riskmetric1$bugs_status <- package_riskmetric1$bugs_status*100
-  package_riskmetric1$export_help <- package_riskmetric1$export_help*100
+  riskmetric_score$bugs_status <- riskmetric_score$bugs_status*100
+  riskmetric_score$export_help <- riskmetric_score$export_help*100
   
 
   db_ins(paste0("INSERT INTO MaintenanceMetrics values(", 
                 "'", package_name, "',", 
-                "'", package_riskmetric1$has_vignettes[1], ",", ifelse(class(package_riskmetric2$has_vignettes[[1]])[1] == "pkg_metric_error", -1, package_riskmetric2$has_vignettes[[1]][1]), "',",
-                "'", package_riskmetric1$has_news[1], ",",  ifelse(class(package_riskmetric2$has_news[[1]])[1] == "pkg_metric_error", -1, package_riskmetric2$has_news[[1]][1]), "',", 
-                "'", package_riskmetric1$news_current[1], ",",  ifelse(class(package_riskmetric2$news_current[[1]])[1] == "pkg_metric_error", -1, package_riskmetric2$news_current[[1]][1]), "',",  
-                "'", package_riskmetric1$has_website[1], ",",  ifelse(class(package_riskmetric2$has_website[[1]])[1] == "pkg_metric_error", -1, package_riskmetric2$has_website[[1]][1]), "',", 
-                "'", package_riskmetric1$has_bug_reports_url[1], ",",  ifelse(class(package_riskmetric2$has_bug_reports_url[[1]])[1] == "pkg_metric_error", -1, package_riskmetric2$has_bug_reports_url[[1]][1]), "',",
-                "'", package_riskmetric1$has_maintainer[1], ",",  ifelse(class(package_riskmetric2$has_maintainer[[1]])[1] == "pkg_metric_error", -1, package_riskmetric2$has_maintainer[[1]][1]), "',", 
-                "'", package_riskmetric1$has_source_control[1], ",",  ifelse(class(package_riskmetric2$has_source_control[[1]])[1] == "pkg_metric_error", -1, package_riskmetric2$has_source_control[[1]][1]), "',",
-                "'", format(round(package_riskmetric1$export_help[1],2)), ",",  ifelse(class(package_riskmetric2$export_help[[1]])[1] == "pkg_metric_error", -1, package_riskmetric2$export_help[[1]][1]), "',",
-                "'", format(round(package_riskmetric1$bugs_status[1],2)), ",",  ifelse(class(package_riskmetric2$bugs_status[[1]])[1] == "pkg_metric_error", -1, package_riskmetric2$bugs_status[[1]][1]), "'", ")"))
+                "'", riskmetric_score$has_vignettes[1], ",", ifelse(class(riskmetric_assess$has_vignettes[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$has_vignettes[[1]][1]), "',",
+                "'", riskmetric_score$has_news[1], ",",  ifelse(class(riskmetric_assess$has_news[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$has_news[[1]][1]), "',",
+                "'", riskmetric_score$news_current[1], ",",  ifelse(class(riskmetric_assess$news_current[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$news_current[[1]][1]), "',",
+                "'", riskmetric_score$has_website[1], ",",  ifelse(class(riskmetric_assess$has_website[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$has_website[[1]][1]), "',",
+                "'", riskmetric_score$has_bug_reports_url[1], ",",  ifelse(class(riskmetric_assess$has_bug_reports_url[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$has_bug_reports_url[[1]][1]), "',",
+                "'", riskmetric_score$has_maintainer[1], ",",  ifelse(class(riskmetric_assess$has_maintainer[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$has_maintainer[[1]][1]), "',",
+                "'", riskmetric_score$has_source_control[1], ",",  ifelse(class(riskmetric_assess$has_source_control[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$has_source_control[[1]][1]), "',",
+                "'", format(round(riskmetric_score$export_help[1],2)), ",",  ifelse(class(riskmetric_assess$export_help[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$export_help[[1]][1]), "',",
+                "'", format(round(riskmetric_score$bugs_status[1],2)), ",",  ifelse(class(riskmetric_assess$bugs_status[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$bugs_status[[1]][1]), "'", ")"))
   
   db_ins(
     paste0( "INSERT INTO TestMetrics values(",
             "'", package_name, "',",  
-            "'", format(round(package_riskmetric1$covr_coverage[1], 2)),",", ifelse(class(package_riskmetric2$covr_coverage[[1]])[1] == "pkg_metric_error", -1, package_riskmetric2$covr_coverage[[1]][1]), "'", ")" )
+            "'", format(round(riskmetric_score$covr_coverage[1], 2)),",", ifelse(class(riskmetric_assess$covr_coverage[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$covr_coverage[[1]][1]), "'", ")" )
   )
   
-  db_ins(paste0( "UPDATE Packageinfo SET score = '", format(round(package_riskmetric1$pkg_score[1], 2)), "'", " WHERE package = '" ,
+  db_ins(paste0( "UPDATE Packageinfo SET score = '", format(round(riskmetric_score$pkg_score[1], 2)), "'", " WHERE package = '" ,
                  package_name, "'"))
  
 }  

--- a/Modules/dbupload.R
+++ b/Modules/dbupload.R
@@ -174,7 +174,7 @@ metric_mm_tm_Info_upload_to_DB <- function(package_name){
                 "'", riskmetric_score$has_bug_reports_url[1], ",",  ifelse(class(riskmetric_assess$has_bug_reports_url[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$has_bug_reports_url[[1]][1]), "',",
                 "'", riskmetric_score$has_maintainer[1], ",",  ifelse(class(riskmetric_assess$has_maintainer[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$has_maintainer[[1]][1]), "',",
                 "'", riskmetric_score$has_source_control[1], ",",  ifelse(class(riskmetric_assess$has_source_control[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$has_source_control[[1]][1]), "',",
-                "'", format(round(riskmetric_score$export_help[1],2)), ",",  ifelse(class(riskmetric_assess$export_help[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$export_help[[1]][1]), "',",
+                "'", format(round(riskmetric_score$export_help[1],2)), ",",  ifelse(class(riskmetric_assess$export_help[[1]])[1] == "pkg_metric_error" || is.na(riskmetric_assess$export_help[[1]]), -1, riskmetric_assess$export_help[[1]][1]), "',",
                 "'", format(round(riskmetric_score$bugs_status[1],2)), ",",  ifelse(class(riskmetric_assess$bugs_status[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$bugs_status[[1]][1]), "'", ")"))
   
   db_ins(

--- a/Server/sidebar.R
+++ b/Server/sidebar.R
@@ -7,17 +7,17 @@
 
 
 # Update the sidebar if a decision was previously made.
-observeEvent(input$select_pack, {
+observeEvent(c(input$select_pack, values$selected_pkg), {
   # Suppose package has been selected with a previously made decision.
-  if (nrow(values$selected_pkg) != 0 && values$selected_pkg$decision != "") {
-    # Update the risk slider using the info saved.
-    updateSliderTextInput(
-      session,
-      "decision",
-      choices = c("Low", "Medium", "High"),
-      selected = values$selected_pkg$decision
-    )
-  }
+  req(input$select_pack != "Select")
+  
+  # Update the risk slider using the info saved.
+  updateSliderTextInput(
+    session,
+    "decision",
+    choices = c("Low", "Medium", "High"),
+    selected = values$selected_pkg$decision
+  )
 })
 
 

--- a/Server/sidebar.R
+++ b/Server/sidebar.R
@@ -5,10 +5,8 @@
 # License: MIT License
 #####################################################################################################################
 
-# Start of the Observes'.
 
-# 1. Observe to update the radiobutton for decistion of the package.
-
+# Update the radiobutton if decision was previously made.
 observe({
   req(input$select_pack)
   if (!identical(values$selected_pkg$decision, character(0))) {
@@ -21,10 +19,10 @@ observe({
       )
     }
   }
-})  # End of the Observe.
+})
 
-#2. Observe to disable and enable the text area comment box's' if decision of the package is empty.
 
+# Disable/enable the comments depending on wether a decision has been made.
 observe({
   req(values$selected_pkg$package)
   if (values$selected_pkg$decision != "") {
@@ -38,9 +36,8 @@ observe({
     enable("overall_comment")
     enable("submit_overall_comment")
   }
-})  # End of the Observe.
+})
 
-# 3. Observe to disable and enable to side bar elements for select pacakge input.
 
 observe({
   req(input$select_pack)
@@ -55,12 +52,10 @@ observe({
     enable("overall_comment")
     enable("submit_overall_comment")
   }
-})  # End of the observe.
+})
 
-# Start of the Render Output's'.
 
-# 1. Render Output to show the select input to select the package from dropdown.
-
+# Output a dropdown ui with available packages.
 output$sel_pack <- renderUI({
   values$packsDB <- db_fun("SELECT package FROM Packageinfo")
   selectizeInput(
@@ -69,10 +64,10 @@ output$sel_pack <- renderUI({
     choices = c("Select", values$packsDB$package),
     selected = "Select"
   )
-})  # End of the render Output.
+})
 
-# 2. Render Output to show the select input to select the version of the selected package.
 
+# Output a dropdown ui with the available versions given the selected package.
 output$sel_ver <- renderUI({
   req(input$select_pack)
   res2 <-
@@ -83,19 +78,21 @@ output$sel_ver <- renderUI({
         "'"
       )
     )
+  
   if (input$select_pack == "Select" || nrow(res2) > 1) {
     Choices <- c("Select", c(res2$version))
   } else{
     Choices <- c(res2$version)
   }
+  
   selectInput("select_ver",
               h3("Select Version:"),
               choices = Choices,
               selected = "Select")
-})  # End of the render Output.
+})
 
-# 3. Render Output to dispaly the status of the selected package.
 
+# Display the review status of the selected package.
 output$status <- renderText({
   if (!is.null(input$select_pack)) {
     if (input$select_pack != "Select") {
@@ -110,10 +107,10 @@ output$status <- renderText({
       paste("<h3>Status: <b>NA</b></h3>")
     }
   }
-})  # End of the render Output.
+})
 
-# 4. Render Output to display the score of the selected package.
 
+# Display the risk score of the selected package.
 output$score <- renderText({
   if (!is.null(input$select_pack)) {
     if (input$select_pack != "Select") {
@@ -122,7 +119,7 @@ output$score <- renderText({
       paste("<h3>Score: <b>NA</b></h3>")
     }
   }
-})  # End of the render output.
+})
 
 # End of the Render Output's'.
 

--- a/Server/sidebar.R
+++ b/Server/sidebar.R
@@ -7,17 +7,14 @@
 
 
 # Update the radiobutton if decision was previously made.
-observe({
-  req(input$select_pack)
-  if (!identical(values$selected_pkg$decision, character(0))) {
-    if (values$selected_pkg$decision != "") {
-      updateSliderTextInput(
-        session,
-        "decision",
-        choices = c("Low", "Medium", "High"),
-        selected = values$selected_pkg$decision
-      )
-    }
+observeEvent(input$select_pack, {
+  if (nrow(values$selected_pkg) != 0 && values$selected_pkg$decision != "") {
+    updateSliderTextInput(
+      session,
+      "decision",
+      choices = c("Low", "Medium", "High"),
+      selected = values$selected_pkg$decision
+    )
   }
 })
 

--- a/Server/sidebar.R
+++ b/Server/sidebar.R
@@ -6,9 +6,11 @@
 #####################################################################################################################
 
 
-# Update the radiobutton if decision was previously made.
+# Update the sidebar if a decision was previously made.
 observeEvent(input$select_pack, {
+  # Suppose package has been selected with a previously made decision.
   if (nrow(values$selected_pkg) != 0 && values$selected_pkg$decision != "") {
+    # Update the risk slider using the info saved.
     updateSliderTextInput(
       session,
       "decision",
@@ -23,6 +25,7 @@ observeEvent(input$select_pack, {
 observe({
   req(values$selected_pkg$package)
   if (values$selected_pkg$decision != "") {
+    # Disable all the decision-related choices.
     disable("decision")
     disable("submit_decision")
     disable("overall_comment")
@@ -149,7 +152,7 @@ observeEvent(input$select_pack, {
       ) 
     updateTextAreaInput(session, "overall_comment", placeholder = paste("current comment:", values$comment_occ$comment))
   }
-})  # End of the observe Event.
+})
 
 # 2. Observe Event to submit the decision for selected package.
 
@@ -304,8 +307,3 @@ observeEvent(input$submit_overall_comment_no, {
   updateTextAreaInput(session, "overall_comment", value = "")
   removeModal()
 })
-
-
-# End of the Observe Event's'
-
-# End of the Sidebar server Module.

--- a/Server/uploadpackage.R
+++ b/Server/uploadpackage.R
@@ -64,12 +64,11 @@ observeEvent(input$uploaded_file, {
   withProgress(message = "Uploading Packages to DB:", value = 0, {
     if (nrow(values$New) != 0) {
       for (i in 1:nrow(values$New)) {
-          new_package<-values$New$package[i]
-          get_packages_info_from_web(new_package)
-          metric_mm_tm_Info_upload_to_DB(new_package)
-          metric_cum_Info_upload_to_DB(new_package)
-          incProgress(1 / nrow(values$New), detail = values$New[i, 1])
-          Sys.sleep(0.1)
+        incProgress(1 / (nrow(values$New) + 1), detail = values$New[i, 1])
+        new_package<-values$New$package[i]
+        get_packages_info_from_web(new_package)
+        metric_mm_tm_Info_upload_to_DB(new_package)
+        metric_cum_Info_upload_to_DB(new_package)
       }
     }
   })

--- a/Server/uploadpackage.R
+++ b/Server/uploadpackage.R
@@ -85,7 +85,7 @@ observeEvent(input$uploaded_file, {
     selected = "Select"
   )
   
-  showNotification(id = "show_notification_id", "Upload completed to DB", type = "message")
+  showNotification(id = "show_notification_id", "Upload completed", type = "message")
   values$upload_complete <- "upload_complete"
   
   # Show the download reports buttons after all the packages have been loaded

--- a/www/main.css
+++ b/www/main.css
@@ -738,10 +738,10 @@ display: none;
 }
 
 #shiny-notification-show_notification_id{
-font-size: 25px;
-margin-top: 34px;
-margin-left: 50px;
-font-weight: bold;
+  font-size: 25px;
+  margin: 0 !important;
+  padding: 30px 0 0 60px !important;
+  font-weight: bold;
 }
 
 sub {


### PR DESCRIPTION
### Main changes
- Remove duplicated call to `riskmetric:: pkg_ref` and `riskmetric::pkg_assess`.
- Detect when `export_help` is NA and display this info accordingly (before: the package `binom` for instance displayed "NA%" in green instead of "NA" in grey).
- When uploading a package, show the progress bar with the name of the package being uploaded.
- Remove system sleep time while uploading a package.
