### PR TITLE
Use db_ins() when INSERTing records into COMMENTS table

### DIFF
--- a/Server/communityusage_metrics.R
+++ b/Server/communityusage_metrics.R
@@ -176,7 +176,7 @@ values$cum_comment_submitted <- "no"
 
 observeEvent(input$submit_cum_comment, {
   if (trimws(input$cum_comment) != "") {
-    db_fun(
+    db_ins(
       paste0(
         "INSERT INTO Comments values('",
         input$select_pack,

--- a/Server/maintenance_metrics.R
+++ b/Server/maintenance_metrics.R
@@ -273,7 +273,7 @@ values$mm_comment_submitted <- "no"
 
 observeEvent(input$submit_mm_comment, {
   if (trimws(input$mm_comment) != "") {
-    db_fun(
+    db_ins(
       paste0(
         "INSERT INTO Comments values('",
         input$select_pack,

--- a/Server/testing_metrics.R
+++ b/Server/testing_metrics.R
@@ -103,7 +103,7 @@ output$tm_commented <- renderText({
 values$tm_comment_submitted <- "no"
 observeEvent(input$submit_tm_comment, {
   if (trimws(input$tm_comment) != "") {
-    db_fun(
+    db_ins(
       paste0(
         "INSERT INTO Comments values('",
         input$select_pack,


### PR DESCRIPTION
fixes WARNING message

`Warning in result_fetch(res@ptr, n = n) :
  SQL statements must be issued with dbExecute() or dbSendStatement() instead of dbGetQuery() or dbSendQuery().`
