### PR TITLE
Created the metric and package_metrics tables, and removed the TestMetrics table

### DIFF
--- a/Modules/dbupload.R
+++ b/Modules/dbupload.R
@@ -189,7 +189,7 @@ metric_mm_tm_Info_upload_to_DB <- function(package_name){
             "'", ifelse(
               class(riskmetric_assess$covr_coverage[[1]])[1] == "pkg_metric_error",
               "pkg_metric_error",
-              riskmetric_assess$covr_coverage[1]), "'",
+              riskmetric_assess$covr_coverage[[1]][1]), "'",
             ")" )
   )
 

--- a/Modules/dbupload.R
+++ b/Modules/dbupload.R
@@ -167,8 +167,8 @@ metric_mm_tm_Info_upload_to_DB <- function(package_name){
   riskmetric_score$export_help <- riskmetric_score$export_help*100
   
 
-  db_ins(paste0("INSERT INTO MaintenanceMetrics values(", 
-                "'", package_name, "',", 
+  db_ins(paste0("INSERT INTO MaintenanceMetrics values(",
+                "'", package_name, "',",
                 "'", riskmetric_score$has_vignettes[1], ",", ifelse(class(riskmetric_assess$has_vignettes[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$has_vignettes[[1]][1]), "',",
                 "'", riskmetric_score$has_news[1], ",",  ifelse(class(riskmetric_assess$has_news[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$has_news[[1]][1]), "',",
                 "'", riskmetric_score$news_current[1], ",",  ifelse(class(riskmetric_assess$news_current[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$news_current[[1]][1]), "',",
@@ -179,12 +179,20 @@ metric_mm_tm_Info_upload_to_DB <- function(package_name){
                 "'", format(round(riskmetric_score$export_help[1],2)), ",",  ifelse(class(riskmetric_assess$export_help[[1]])[1] == "pkg_metric_error" || is.na(riskmetric_assess$export_help[[1]]), -1, riskmetric_assess$export_help[[1]][1]), "',",
                 "'", format(round(riskmetric_score$bugs_status[1],2)), ",",  ifelse(class(riskmetric_assess$bugs_status[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$bugs_status[[1]][1]), "'", ")"))
   
+  metric_id <- db_fun(paste0("SELECT id FROM metric WHERE name = 'covr_coverage';"))
+  package_id <- db_fun(paste0("SELECT id FROM package WHERE name = ", "'", package_name, "';"))
   db_ins(
-    paste0( "INSERT INTO TestMetrics values(",
-            "'", package_name, "',",  
-            "'", format(round(riskmetric_score$covr_coverage[1], 2)),",", ifelse(class(riskmetric_assess$covr_coverage[[1]])[1] == "pkg_metric_error", -1, riskmetric_assess$covr_coverage[[1]][1]), "'", ")" )
+    paste0( "INSERT INTO package_metrics (package_id, metric_id, weight, value) values(",
+            package_id, ",",
+            metric_id, ",",
+            "1" , "," ,
+            "'", ifelse(
+              class(riskmetric_assess$covr_coverage[[1]])[1] == "pkg_metric_error",
+              "pkg_metric_error",
+              riskmetric_assess$covr_coverage[1]), "'",
+            ")" )
   )
-  
+
   db_ins(paste0( "UPDATE package SET score = '", format(round(riskmetric_score$pkg_score[1], 2)), "'", " WHERE name = '" ,
                  package_name, "'"))
  
@@ -195,7 +203,7 @@ metric_mm_tm_Info_upload_to_DB <- function(package_name){
 # 4. Function to get community usage metrics info and upload into DB.
 
 metric_cum_Info_upload_to_DB <- function(package_name) {
-  pkg_vers_date_final<<-data.frame(matrix(ncol = 4, nrow = 0))
+  pkg_vers_date_final <<- data.frame(matrix(ncol = 4, nrow = 0))
   time_since_first_release<<-NA
   time_since_version_release<<-NA
   downloads_1yr<<-NA
@@ -295,7 +303,7 @@ metric_cum_Info_upload_to_DB <- function(package_name) {
              app = "fileupload-webscraping", echo = FALSE)
     }
   )# End of try catch
-  
+
   for (i in 1:nrow(pkg_vers_date_final)) {
     db_ins(paste0("INSERT INTO CommunityUsageMetrics values(",
                   "'", package_name,"',", "'", downloads_1yr, "',",

--- a/Reports/Report_doc.Rmd
+++ b/Reports/Report_doc.Rmd
@@ -74,16 +74,17 @@ comment_o <-
   no_of_downloads_last_year_info <-
         riskmetrics_cum$no_of_downloads_last_year[1]
   
-  riskmetrics_tm <-
-    db_fun(
-      paste0(
-        "SELECT * FROM TestMetrics WHERE TestMetrics.tm_id ='",
-        params$package,
-        "'"
-      )
+  package_id <- db_fun(paste0("SELECT id FROM package WHERE name = ", "'", input$select_pack, "'", ";"))
+  metric_id <- db_fun(paste0("SELECT id FROM metric WHERE class = 'code_coverage';"))
+  code_coverage <- db_fun(
+    paste0("SELECT value FROM package_metrics WHERE ",
+           "package_id = ", package_id,
+           " AND ",
+           "metric_id = ", metric_id,
+           ";"
     )
-  riskmetrics_tm <- c(strsplit(riskmetrics_tm$test_coverage,",")[[1]][1], strsplit(riskmetrics_tm$test_coverage,",")[[1]][2])
-  
+  )
+  code_coverage <- code_coverage$value
 
    comment_mm <-
       db_fun(
@@ -304,17 +305,21 @@ table_cum<-data.frame("User ID"=comment_cum$user_name,"Role"= comment_cum$user_r
   bands = data.frame(
     start = c(0, 40, 80),
     end = c(40, 80, 100),
-    color = ifelse(riskmetrics_tm[2] != -1, c("#ea3838", "#ffac29", "#00CC00"), c("#808080", "#808080", "#808080")),
+    color = ifelse(code_coverage != "pkg_metric_error",
+                   c("#ea3838", "#ffac29", "#00CC00"),
+                   c("#808080", "#808080", "#808080")),
     stringsAsFactors = FALSE
   )
   bands2 = data.frame(
     start = c(0, 40, 80),
     end = c(40, 80, 100),
-    color = ifelse(riskmetrics_tm[2] != -1, c("#ea3838", "#ffac29", "#00CC00"), c("#808080", "#808080", "#808080")),
+    color = ifelse(code_coverage != "pkg_metric_error",
+                   c("#ea3838", "#ffac29", "#00CC00"),
+                   c("#808080", "#808080", "#808080")),
     stringsAsFactors = FALSE
   )
   amAngularGauge(
-    x = as.numeric(ifelse(riskmetrics_tm[1] == "NA", 0, riskmetrics_tm[1])),
+    x = as.numeric(ifelse(code_coverage == "NA", 0, code_coverage)),
     start = 0,
     end = 100,
     bands = bands,
@@ -337,9 +342,6 @@ table_tm<-data.frame("User ID"=comment_tm$user_name,"Role"= comment_tm$user_role
 
 
 ```
-
-
-
 
 
 

--- a/Reports/Report_doc.Rmd
+++ b/Reports/Report_doc.Rmd
@@ -75,8 +75,8 @@ comment_o <-
         riskmetrics_cum$no_of_downloads_last_year[1]
   
   package_id <- db_fun(paste0("SELECT id FROM package WHERE name = ", "'", input$select_pack, "'", ";"))
-  metric_id <- db_fun(paste0("SELECT id FROM metric WHERE class = 'code_coverage';"))
-  code_coverage <- db_fun(
+  metric_id <- db_fun(paste0("SELECT id FROM metric WHERE name = 'covr_coverage';"))
+  covr_coverage <- db_fun(
     paste0("SELECT value FROM package_metrics WHERE ",
            "package_id = ", package_id,
            " AND ",
@@ -84,7 +84,7 @@ comment_o <-
            ";"
     )
   )
-  code_coverage <- code_coverage$value
+  covr_coverage <- covr_coverage$value
 
    comment_mm <-
       db_fun(
@@ -305,7 +305,7 @@ table_cum<-data.frame("User ID"=comment_cum$user_name,"Role"= comment_cum$user_r
   bands = data.frame(
     start = c(0, 40, 80),
     end = c(40, 80, 100),
-    color = ifelse(code_coverage != "pkg_metric_error",
+    color = ifelse(covr_coverage != "pkg_metric_error",
                    c("#ea3838", "#ffac29", "#00CC00"),
                    c("#808080", "#808080", "#808080")),
     stringsAsFactors = FALSE
@@ -313,13 +313,13 @@ table_cum<-data.frame("User ID"=comment_cum$user_name,"Role"= comment_cum$user_r
   bands2 = data.frame(
     start = c(0, 40, 80),
     end = c(40, 80, 100),
-    color = ifelse(code_coverage != "pkg_metric_error",
+    color = ifelse(covr_coverage != "pkg_metric_error",
                    c("#ea3838", "#ffac29", "#00CC00"),
                    c("#808080", "#808080", "#808080")),
     stringsAsFactors = FALSE
   )
   amAngularGauge(
-    x = as.numeric(ifelse(code_coverage == "NA", 0, code_coverage)),
+    x = as.numeric(ifelse(covr_coverage == "NA", 0, covr_coverage)),
     start = 0,
     end = 100,
     bands = bands,

--- a/Reports/Report_html.Rmd
+++ b/Reports/Report_html.Rmd
@@ -74,15 +74,18 @@ comment_o <-
   no_of_downloads_last_year_info <-
         riskmetrics_cum$no_of_downloads_last_year[1]
   
-  riskmetrics_tm <-
-    db_fun(
-      paste0(
-        "SELECT * FROM TestMetrics WHERE TestMetrics.tm_id ='",
-        params$package,
-        "'"
-      )
+
+  package_id <- db_fun(paste0("SELECT id FROM package WHERE name = ", "'", input$select_pack, "'", ";"))
+  metric_id <- db_fun(paste0("SELECT id FROM metric WHERE class = 'code_coverage';"))
+  code_coverage <- db_fun(
+    paste0("SELECT value FROM package_metrics WHERE ",
+           "package_id = ", package_id,
+           " AND ",
+           "metric_id = ", metric_id,
+           ";"
     )
-  riskmetrics_tm <- c(strsplit(riskmetrics_tm$test_coverage,",")[[1]][1], strsplit(riskmetrics_tm$test_coverage,",")[[1]][2])
+  )
+  code_coverage <- code_coverage$value
   
 
    comment_mm <-
@@ -479,17 +482,21 @@ comment_cum <- data.frame(comment_cum %>% map(rev))
   bands = data.frame(
     start = c(0, 40, 80),
     end = c(40, 80, 100),
-    color = ifelse(riskmetrics_tm[2] != -1, c("#ea3838", "#ffac29", "#00CC00"), c("#808080", "#808080", "#808080")),
+    color = ifelse(code_coverage != "pkg_metric_error",
+                   c("#ea3838", "#ffac29", "#00CC00"),
+                   c("#808080", "#808080", "#808080")),
     stringsAsFactors = FALSE
   )
   bands2 = data.frame(
     start = c(0, 40, 80),
     end = c(40, 80, 100),
-    color = ifelse(riskmetrics_tm[2] != -1, c("#ea3838", "#ffac29", "#00CC00"), c("#808080", "#808080", "#808080")),
+    color = ifelse(code_coverage != "pkg_metric_error",
+                   c("#ea3838", "#ffac29", "#00CC00"),
+                   c("#808080", "#808080", "#808080")),
     stringsAsFactors = FALSE
   )
   amAngularGauge(
-    x = as.numeric(ifelse(riskmetrics_tm[1] == "NA", 0, riskmetrics_tm[1])),
+    x = as.numeric(ifelse(code_coverage == "NA", 0, code_coverage)),
     start = 0,
     end = 100,
     bands = bands,
@@ -502,7 +509,7 @@ comment_cum <- data.frame(comment_cum %>% map(rev))
 
 ```{r echo=FALSE}
 
-if(riskmetrics_tm[2] == -1){
+if(code_coverage == "pkg_metric_error"){
   tags$script(HTML(
   "
   setTimeout(function() {

--- a/Reports/Report_html.Rmd
+++ b/Reports/Report_html.Rmd
@@ -76,8 +76,8 @@ comment_o <-
   
 
   package_id <- db_fun(paste0("SELECT id FROM package WHERE name = ", "'", input$select_pack, "'", ";"))
-  metric_id <- db_fun(paste0("SELECT id FROM metric WHERE class = 'code_coverage';"))
-  code_coverage <- db_fun(
+  metric_id <- db_fun(paste0("SELECT id FROM metric WHERE name = 'covr_coverage';"))
+  covr_coverage <- db_fun(
     paste0("SELECT value FROM package_metrics WHERE ",
            "package_id = ", package_id,
            " AND ",
@@ -85,7 +85,7 @@ comment_o <-
            ";"
     )
   )
-  code_coverage <- code_coverage$value
+  covr_coverage <- covr_coverage$value
   
 
    comment_mm <-
@@ -482,7 +482,7 @@ comment_cum <- data.frame(comment_cum %>% map(rev))
   bands = data.frame(
     start = c(0, 40, 80),
     end = c(40, 80, 100),
-    color = ifelse(code_coverage != "pkg_metric_error",
+    color = ifelse(covr_coverage != "pkg_metric_error",
                    c("#ea3838", "#ffac29", "#00CC00"),
                    c("#808080", "#808080", "#808080")),
     stringsAsFactors = FALSE
@@ -490,13 +490,13 @@ comment_cum <- data.frame(comment_cum %>% map(rev))
   bands2 = data.frame(
     start = c(0, 40, 80),
     end = c(40, 80, 100),
-    color = ifelse(code_coverage != "pkg_metric_error",
+    color = ifelse(covr_coverage != "pkg_metric_error",
                    c("#ea3838", "#ffac29", "#00CC00"),
                    c("#808080", "#808080", "#808080")),
     stringsAsFactors = FALSE
   )
   amAngularGauge(
-    x = as.numeric(ifelse(code_coverage == "NA", 0, code_coverage)),
+    x = as.numeric(ifelse(covr_coverage == "NA", 0, covr_coverage)),
     start = 0,
     end = 100,
     bands = bands,
@@ -509,7 +509,7 @@ comment_cum <- data.frame(comment_cum %>% map(rev))
 
 ```{r echo=FALSE}
 
-if(code_coverage == "pkg_metric_error"){
+if(covr_coverage == "pkg_metric_error"){
   tags$script(HTML(
   "
   setTimeout(function() {

--- a/Server/db_dash_screen.R
+++ b/Server/db_dash_screen.R
@@ -79,7 +79,7 @@ output$dwnld_sel_db_pkgs_btn <- downloadHandler(
         fs <- c()
         for (i in 1:n_pkgs) {
           # Grab package name and version, then create filename and path.
-          this_pkg <- these_pkgs$package[i]
+          this_pkg <- these_pkgs$name[i]
           this_ver <- these_pkgs$version[i]
           file_named <- paste0(this_pkg,"_",this_ver,"_Risk_Assessment.",input$report_formats)
           path <- file.path(my_dir, file_named)

--- a/Server/testing_metrics.R
+++ b/Server/testing_metrics.R
@@ -9,7 +9,7 @@
 
 # 1. Observe to load the columns from DB into below reactive values.
 
-observe({
+observeEvent(input$tabs, {
   req(input$select_pack)
   if (input$tabs == "tm_tab_value") {
     if (input$select_pack != "Select") {

--- a/Server/testing_metrics.R
+++ b/Server/testing_metrics.R
@@ -15,7 +15,7 @@ observeEvent(input$tabs, {
     if (input$select_pack != "Select") {
       
       package_id <- db_fun(paste0("SELECT id FROM package WHERE name = ", "'", input$select_pack, "'", ";"))
-      metric_id <- db_fun(paste0("SELECT id FROM metric WHERE class = 'code_coverage';"))
+      metric_id <- db_fun(paste0("SELECT id FROM metric WHERE name = 'covr_coverage';"))
       
       values$code_coverage <- db_fun(
         paste0("SELECT value FROM package_metrics WHERE ",

--- a/Server/testing_metrics.R
+++ b/Server/testing_metrics.R
@@ -17,7 +17,7 @@ observeEvent(input$tabs, {
       package_id <- db_fun(paste0("SELECT id FROM package WHERE name = ", "'", input$select_pack, "'", ";"))
       metric_id <- db_fun(paste0("SELECT id FROM metric WHERE name = 'covr_coverage';"))
       
-      values$code_coverage <- db_fun(
+      values$covr_coverage <- db_fun(
         paste0("SELECT value FROM package_metrics WHERE ",
                "package_id = ", package_id,
                " AND ",
@@ -25,10 +25,10 @@ observeEvent(input$tabs, {
                ";"
         )
       )
-      values$code_coverage <- values$code_coverage$value
+      values$covr_coverage <- values$covr_coverage$value
       
       if (!is.null(input$tm_comment)) {
-        if(values$code_coverage == "pkg_metric_error")
+        if(values$covr_coverage == "pkg_metric_error")
           runjs( "setTimeout(function(){ addTextToGaugeSVG('test_coverage');}, 500);" )
         
         req(values$selected_pkg$decision)
@@ -52,7 +52,7 @@ output$test_coverage <- renderAmCharts({
   bands = data.frame(
     start = c(0, 40, 80),
     end = c(40, 80, 100),
-    color = ifelse(values$code_coverage != "pkg_metric_error",
+    color = ifelse(values$covr_coverage != "pkg_metric_error",
                    c("#ea3838", "#ffac29", "#00CC00"),
                    c("#808080", "#808080", "#808080")),
     stringsAsFactors = FALSE
@@ -60,13 +60,13 @@ output$test_coverage <- renderAmCharts({
   bands2 = data.frame(
     start = c(0, 40, 80),
     end = c(40, 80, 100),
-    color = ifelse(values$code_coverage != "pkg_metric_error",
+    color = ifelse(values$covr_coverage != "pkg_metric_error",
                    c("#ea3838", "#ffac29", "#00CC00"),
                    c("#808080", "#808080", "#808080")),
     stringsAsFactors = FALSE
   )
   amAngularGauge(
-    x = as.numeric(ifelse(values$code_coverage == "NA", 0, values$code_coverage)),
+    x = as.numeric(ifelse(values$covr_coverage == "NA", 0, values$covr_coverage)),
     start = 0,
     end = 100,
     bands = bands,

--- a/Server/testing_metrics.R
+++ b/Server/testing_metrics.R
@@ -13,20 +13,26 @@ observeEvent(input$tabs, {
   req(input$select_pack)
   if (input$tabs == "tm_tab_value") {
     if (input$select_pack != "Select") {
-    
-      values$riskmetrics_tm <-
-        db_fun(
-          paste0(
-            "SELECT * FROM TestMetrics WHERE TestMetrics.tm_id ='",
-            input$select_pack,
-            "'"
-          )
-        )
-      values$test_coverage <- c(strsplit(values$riskmetrics_tm$test_coverage,",")[[1]][1], strsplit(values$riskmetrics_tm$test_coverage,",")[[1]][2])
       
+      package_id <- db_fun(paste0("SELECT id FROM package WHERE name = ", "'", input$select_pack, "'", ";"))
+      metric_id <- db_fun(paste0("SELECT id FROM metric WHERE class = 'code_coverage';"))
+      
+      values$code_coverage <- db_fun(
+        paste0("SELECT value FROM package_metrics WHERE ",
+               "package_id = ", package_id,
+               " AND ",
+               "metric_id = ", metric_id,
+               ";"
+        )
+      )
+      values$code_coverage <- values$code_coverage$value
+    
     if (!is.null(input$tm_comment)) {
-      if(values$test_coverage[2] == -1){ runjs( "setTimeout(function(){ addTextToGaugeSVG('test_coverage');}, 500);" ) }
+      if(values$code_coverage == "pkg_metric_error")
+        runjs( "setTimeout(function(){ addTextToGaugeSVG('test_coverage');}, 500);" )
+      
       req(values$selected_pkg$decision)
+      
       if (values$selected_pkg$decision != "") {
         runjs("setTimeout(function(){ var ele = document.getElementById('tm_comment'); ele.disabled = true; }, 500);")
         runjs("setTimeout(function(){ var ele = document.getElementById('submit_tm_comment'); ele.disabled = true; }, 500);")
@@ -46,17 +52,21 @@ output$test_coverage <- renderAmCharts({
   bands = data.frame(
     start = c(0, 40, 80),
     end = c(40, 80, 100),
-    color = ifelse(values$test_coverage[2] != -1, c("#ea3838", "#ffac29", "#00CC00"), c("#808080", "#808080", "#808080")),
+    color = ifelse(values$code_coverage != "pkg_metric_error",
+                   c("#ea3838", "#ffac29", "#00CC00"),
+                   c("#808080", "#808080", "#808080")),
     stringsAsFactors = FALSE
   )
   bands2 = data.frame(
     start = c(0, 40, 80),
     end = c(40, 80, 100),
-    color = ifelse(values$test_coverage[2] != -1, c("#ea3838", "#ffac29", "#00CC00"), c("#808080", "#808080", "#808080")),
+    color = ifelse(values$code_coverage != "pkg_metric_error",
+                   c("#ea3838", "#ffac29", "#00CC00"),
+                   c("#808080", "#808080", "#808080")),
     stringsAsFactors = FALSE
   )
   amAngularGauge(
-    x = as.numeric(ifelse(values$test_coverage[1] == "NA", 0, values$test_coverage[1])),
+    x = as.numeric(ifelse(values$code_coverage == "NA", 0, values$code_coverage)),
     start = 0,
     end = 100,
     bands = bands,

--- a/Server/testing_metrics.R
+++ b/Server/testing_metrics.R
@@ -26,18 +26,18 @@ observeEvent(input$tabs, {
         )
       )
       values$code_coverage <- values$code_coverage$value
-    
-    if (!is.null(input$tm_comment)) {
-      if(values$code_coverage == "pkg_metric_error")
-        runjs( "setTimeout(function(){ addTextToGaugeSVG('test_coverage');}, 500);" )
       
-      req(values$selected_pkg$decision)
-      
-      if (values$selected_pkg$decision != "") {
-        runjs("setTimeout(function(){ var ele = document.getElementById('tm_comment'); ele.disabled = true; }, 500);")
-        runjs("setTimeout(function(){ var ele = document.getElementById('submit_tm_comment'); ele.disabled = true; }, 500);")
-      } 
-     }
+      if (!is.null(input$tm_comment)) {
+        if(values$code_coverage == "pkg_metric_error")
+          runjs( "setTimeout(function(){ addTextToGaugeSVG('test_coverage');}, 500);" )
+        
+        req(values$selected_pkg$decision)
+        
+        if (values$selected_pkg$decision != "") {
+          runjs("setTimeout(function(){ var ele = document.getElementById('tm_comment'); ele.disabled = true; }, 500);")
+          runjs("setTimeout(function(){ var ele = document.getElementById('submit_tm_comment'); ele.disabled = true; }, 500);")
+        }
+      }
     }
   }
 })  # End of the observe.

--- a/Server/tm_report.R
+++ b/Server/tm_report.R
@@ -10,19 +10,22 @@ observeEvent(input$tabs, {
   req(input$select_pack)
   if (input$tabs == "reportPreview_tab_value") {
     if(input$select_pack != "Select"){
-    
-      values$riskmetrics_tm <-
-        db_fun(
-          paste0(
-            "SELECT * FROM TestMetrics WHERE TestMetrics.tm_id ='",
-            input$select_pack,
-            "'"
-          )
-        )
-      values$test_coverage <- c(strsplit(values$riskmetrics_tm$test_coverage,",")[[1]][1], strsplit(values$riskmetrics_tm$test_coverage,",")[[1]][2])
       
-      req(values$test_coverage)
-      if(values$test_coverage[2] == -1){ runjs( "setTimeout(function(){ addTextToGaugeSVG('test_coverage1');}, 5000);" ) }
+      package_id <- db_fun(paste0("SELECT id FROM package WHERE name = ", "'", input$select_pack, "'", ";"))
+      metric_id <- db_fun(paste0("SELECT id FROM metric WHERE class = 'code_coverage';"))
+      values$code_coverage <- db_fun(
+        paste0("SELECT value FROM package_metrics WHERE ",
+               "package_id = ", package_id,
+               " AND ",
+               "metric_id = ", metric_id,
+               ";"
+        )
+      )
+      values$code_coverage <- values$code_coverage$value
+      
+      req(values$code_coverage)
+      if(values$code_coverage == "pkg_metric_error")
+        runjs("setTimeout(function(){ addTextToGaugeSVG('test_coverage1');}, 5000);")
     }
   }
 })  # End of the observe.
@@ -37,17 +40,21 @@ output$test_coverage1 <- renderAmCharts({
   bands = data.frame(
     start = c(0, 40, 80),
     end = c(40, 80, 100),
-    color = ifelse(values$test_coverage[2] != -1, c("#ea3838", "#ffac29", "#00CC00"), c("#808080", "#808080", "#808080")),
+    color = ifelse(values$code_coverage != "pkg_metric_error",
+                   c("#ea3838", "#ffac29", "#00CC00"),
+                   c("#808080", "#808080", "#808080")),
     stringsAsFactors = FALSE
   )
   bands2 = data.frame(
     start = c(0, 40, 80),
     end = c(40, 80, 100),
-    color = ifelse(values$test_coverage[2] != -1, c("#ea3838", "#ffac29", "#00CC00"), c("#808080", "#808080", "#808080")),
+    color = ifelse(values$code_coverage != "pkg_metric_error",
+                   c("#ea3838", "#ffac29", "#00CC00"),
+                   c("#808080", "#808080", "#808080")),
     stringsAsFactors = FALSE
   )
   amAngularGauge(
-    x = as.numeric(ifelse(values$test_coverage[1] == "NA", 0, values$test_coverage[1])),
+    x = as.numeric(ifelse(values$code_coverage == "NA", 0, values$code_coverage)),
     start = 0,
     end = 100,
     bands = bands,

--- a/Server/tm_report.R
+++ b/Server/tm_report.R
@@ -12,8 +12,8 @@ observeEvent(input$tabs, {
     if(input$select_pack != "Select"){
       
       package_id <- db_fun(paste0("SELECT id FROM package WHERE name = ", "'", input$select_pack, "'", ";"))
-      metric_id <- db_fun(paste0("SELECT id FROM metric WHERE class = 'code_coverage';"))
-      values$code_coverage <- db_fun(
+      metric_id <- db_fun(paste0("SELECT id FROM metric WHERE name = 'covr_coverage';"))
+      values$covr_coverage <- db_fun(
         paste0("SELECT value FROM package_metrics WHERE ",
                "package_id = ", package_id,
                " AND ",

--- a/Server/tm_report.R
+++ b/Server/tm_report.R
@@ -21,10 +21,10 @@ observeEvent(input$tabs, {
                ";"
         )
       )
-      values$code_coverage <- values$code_coverage$value
+      values$covr_coverage <- values$covr_coverage$value
       
-      req(values$code_coverage)
-      if(values$code_coverage == "pkg_metric_error")
+      req(values$covr_coverage)
+      if(values$covr_coverage == "pkg_metric_error")
         runjs("setTimeout(function(){ addTextToGaugeSVG('test_coverage1');}, 5000);")
     }
   }
@@ -40,7 +40,7 @@ output$test_coverage1 <- renderAmCharts({
   bands = data.frame(
     start = c(0, 40, 80),
     end = c(40, 80, 100),
-    color = ifelse(values$code_coverage != "pkg_metric_error",
+    color = ifelse(values$covr_coverage != "pkg_metric_error",
                    c("#ea3838", "#ffac29", "#00CC00"),
                    c("#808080", "#808080", "#808080")),
     stringsAsFactors = FALSE
@@ -48,13 +48,13 @@ output$test_coverage1 <- renderAmCharts({
   bands2 = data.frame(
     start = c(0, 40, 80),
     end = c(40, 80, 100),
-    color = ifelse(values$code_coverage != "pkg_metric_error",
+    color = ifelse(values$covr_coverage != "pkg_metric_error",
                    c("#ea3838", "#ffac29", "#00CC00"),
                    c("#808080", "#808080", "#808080")),
     stringsAsFactors = FALSE
   )
   amAngularGauge(
-    x = as.numeric(ifelse(values$code_coverage == "NA", 0, values$code_coverage)),
+    x = as.numeric(ifelse(values$covr_coverage == "NA", 0, values$covr_coverage)),
     start = 0,
     end = 100,
     bands = bands,

--- a/Server/tm_report.R
+++ b/Server/tm_report.R
@@ -6,7 +6,7 @@
 #####################################################################################################################
 
 # 1. Observe to check the report preview value
-observe({
+observeEvent(input$tabs, {
   req(input$select_pack)
   if (input$tabs == "reportPreview_tab_value") {
     if(input$select_pack != "Select"){

--- a/Utils/sql_queries/create_TestMetrics_table.sql
+++ b/Utils/sql_queries/create_TestMetrics_table.sql
@@ -1,5 +1,0 @@
-CREATE TABLE IF NOT EXISTS TestMetrics (
-   tm_id 		  CHAR NOT NULL, 
-   test_coverage CHAR,
-   FOREIGN KEY(tm_id) REFERENCES package(name)
-);

--- a/Utils/sql_queries/create_metric_table.sql
+++ b/Utils/sql_queries/create_metric_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS metric(
+   id           INTEGER PRIMARY KEY AUTOINCREMENT,
+   name         CHAR, 
+   description  CHAR,
+   class        CHAR, /*class = maintenance or code_coverage*/
+   weight       INT
+);

--- a/Utils/sql_queries/create_metric_table.sql
+++ b/Utils/sql_queries/create_metric_table.sql
@@ -2,6 +2,6 @@ CREATE TABLE IF NOT EXISTS metric(
    id           INTEGER PRIMARY KEY AUTOINCREMENT,
    name         CHAR, 
    description  CHAR,
-   class        CHAR, /*class = maintenance or code_coverage*/
+   class        CHAR, /*class = maintenance or test*/
    weight       INT
 );

--- a/Utils/sql_queries/create_package_metrics_table.sql
+++ b/Utils/sql_queries/create_package_metrics_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS package_metrics(
+   id           INTEGER PRIMARY KEY AUTOINCREMENT,
+   package_id   INT, 
+   metric_id    INT,
+   value        CHAR, /*a value equal to 'pkg_metric_error' indicates an error*/
+   weight       INT,
+   FOREIGN KEY (package_id) REFERENCES package(id),
+   FOREIGN KEY (metric_id) REFERENCES metric(id)
+);

--- a/Utils/sql_queries/initialize_metric_table.sql
+++ b/Utils/sql_queries/initialize_metric_table.sql
@@ -1,0 +1,11 @@
+INSERT INTO metric (name, description, class, weight) values 
+('package_has_vignettes', '', 'maintenance', 1),
+('news_is_current', '', 'maintenance', 1),
+('has_bug_reports', '', 'maintenance', 1),
+('package_has_website', '', 'maintenance', 1),
+('news_is_current', '', 'maintenance', 1),
+('has_a_package_maintainer', '', 'maintenance', 1),
+('source_code_is_public', '', 'maintenance', 1),
+('exported_objects_with_documentation', '', 'maintenance', 1),
+('status_of_last_30_reported_bugs', '', 'maintenance', 1),
+('covr_coverage', '', 'code_coverage', 1);

--- a/Utils/sql_queries/initialize_metric_table.sql
+++ b/Utils/sql_queries/initialize_metric_table.sql
@@ -8,4 +8,4 @@ INSERT INTO metric (name, description, class, weight) values
 ('source_code_is_public', '', 'maintenance', 1),
 ('exported_objects_with_documentation', '', 'maintenance', 1),
 ('status_of_last_30_reported_bugs', '', 'maintenance', 1),
-('covr_coverage', '', 'code_coverage', 1);
+('covr_coverage', '', 'test', 1);

--- a/Utils/utils.R
+++ b/Utils/utils.R
@@ -25,7 +25,6 @@ create_db <- function(){
     "create_package_metrics_table.sql",
     "create_MaintenanceMetrics_table.sql",
     "create_CommunityUsageMetrics_table.sql",
-    "create_TestMetrics_table.sql",
     "create_Comments_table.sql"
   )
   

--- a/Utils/utils.R
+++ b/Utils/utils.R
@@ -20,6 +20,9 @@ create_db <- function(){
   # Queries needed to run the first time the db is created.
   queries <- c(
     "create_package_table.sql",
+    "create_metric_table.sql",
+    "initialize_metric_table.sql",
+    "create_package_metrics_table.sql",
     "create_MaintenanceMetrics_table.sql",
     "create_CommunityUsageMetrics_table.sql",
     "create_TestMetrics_table.sql",


### PR DESCRIPTION
## Major changes
- Created a table called `metric` to store metric information
- Created a table called `package_metrics` to store metric information per package
- Removed the `TestMetrics` table and moved the information on this table to `metric` and `package_metrics` accordingly

_Notes_: 
- The table `MaintenanceMetrics` hasn't been migrated to `metric` and `package_metrics`. Such change should be part of the next PR.
- The name `package_metrics` is not set in stone. I tried to portray that this is a one-to-many relationship (mmm although it will contain multiple packages). I'm open to suggestions =)