### PR TITLE
Add ui elements to view/change metrics weights

### DIFF
--- a/Data/maintenance.txt
+++ b/Data/maintenance.txt
@@ -1,1 +1,0 @@
-Best practices in software development and maintenance can significantly reduce the potential for bugs / errors.  Package maintainers are not obliged to share their practices (and rarely do), however the open source community provides several ways of measuring best practice.  The R Validation Hub proposes the following metrics.

--- a/Modules/dbupload.R
+++ b/Modules/dbupload.R
@@ -167,7 +167,7 @@ metric_mm_tm_Info_upload_to_DB <- function(package_name){
   
   # Insert all the metrics (columns of class "pkg_score") into the db.
   # TODO: Are pkg_score and pkg_metric_error mutually exclusive?
-  for(row in 1:length(metric_weights_df)){
+  for(row in 1:nrow(metric_weights_df)){
     metric <- metric_weights_df %>% slice(row)
     # If the metric is not part of the assessment, then skip iteration.
     if(!(metric$name %in% colnames(riskmetric_score))) next

--- a/Modules/dbupload.R
+++ b/Modules/dbupload.R
@@ -167,7 +167,7 @@ metric_mm_tm_Info_upload_to_DB <- function(package_name){
   
   # Insert all the metrics (columns of class "pkg_score") into the db.
   # TODO: Are pkg_score and pkg_metric_error mutually exclusive?
-  for(row in length(metric_weights_df)){
+  for(row in 1:length(metric_weights_df)){
     metric <- metric_weights_df %>% slice(row)
     # If the metric is not part of the assessment, then skip iteration.
     if(!(metric$name %in% colnames(riskmetric_score))) next

--- a/Modules/dbupload.R
+++ b/Modules/dbupload.R
@@ -170,12 +170,12 @@ metric_mm_tm_Info_upload_to_DB <- function(package_name){
   for(metric_name in colnames(riskmetric_score)){
     if("pkg_score" %in% class(riskmetric_score[[metric_name]])){
       
-      metric_id <- db_fun(paste0("SELECT id, class
+      metric_info <- db_fun(paste0("SELECT id, class, weight
                                  FROM metric
                                  WHERE name = ", "'", metric_name, "'", ";"))
       
       # Skip if the metric is not on the metrics table.
-      if(nrow(metric_id) == 0) next
+      if(nrow(metric_info) == 0) next
       
       # If the metric errors out,
       #   then save "pkg_metric_error" as the value of the metric.
@@ -197,8 +197,8 @@ metric_mm_tm_Info_upload_to_DB <- function(package_name){
         paste0("INSERT INTO package_metrics
                (package_id, metric_id, weight, value) values(",
                 package_id, ",",
-                metric_id$id, ",",
-                "1" , "," ,
+                metric_info$id, ",",
+                metric_info$weight , "," ,
                 "'", metric_value, "'",
                 ")"
         )

--- a/Modules/dbupload.R
+++ b/Modules/dbupload.R
@@ -147,9 +147,14 @@ metric_mm_tm_Info_upload_to_DB <- function(package_name){
     as_tibble() %>%
     pkg_assess()
   
+  # Get the metrics weights to be used during pkg_score.
+  metric_weights_df <- db_fun(paste0("SELECT name, weight FROM metric"))
+  metric_weights <- metric_weights_df$weight
+  names(metric_weights) <- metric_weights_df$name
+  
   riskmetric_score <-
     riskmetric_assess %>%
-    pkg_score()
+    pkg_score(weights = metric_weights)
   
   package_id <- db_fun(paste0("SELECT id FROM package WHERE name = ", "'", package_name, "';"))
   

--- a/Server/assessment_criteria.R
+++ b/Server/assessment_criteria.R
@@ -5,11 +5,19 @@
 # License: MIT License
 ###############################################################################
 
+maintenance_metrics_text <- "<h4>Best practices in software development and
+maintenance can significantly reduce the potential for bugs / errors.
+Package maintainers are not obliged to share their practices (and rarely do),
+however the open source community provides several ways of measuring software
+development best practices. The R Validation Hub proposes the following
+metrics based on the white paper
+<a target='_blank' href='https://www.pharmar.org/presentations/r_packages-white_paper.pdf'>
+A Risk-based Approach for Assessing R package Accuracy within a Validated
+Infrastructure</a>.</h4>"
 
-# Display the Maintenance Metrics text content.
-output$maintenance_desc <- renderText({
-  desc_maintenance <- read_file(file.path("Data", "maintenance.txt"))
-  paste("<h4>", desc_maintenance, "</h4>")
+# Display the Maintenance Metrics description.
+output$maintenance_desc <- renderUI({
+  HTML(maintenance_metrics_text)
 })
 
 

--- a/Server/db_dash_screen.R
+++ b/Server/db_dash_screen.R
@@ -138,3 +138,84 @@ output$dwnld_sel_db_pkgs_btn <- downloadHandler(
 observeEvent(input$back2dash, {
   values$current_screen <- "dashboard_screen"
 })
+
+metrics_weight <- reactive({
+  input$update_weight
+  get_metric_weights()
+})
+
+output$weights_table <- DT::renderDataTable({
+  
+  as.datatable(
+    formattable(metrics_weight()),
+    selection = list(mode = 'single'),
+    colnames = c("Name", "Weight"),
+    rownames = FALSE,
+    options = list(
+      searching = FALSE,
+      lengthChange = FALSE,
+      pageLength = 10,
+      columnDefs = list(list(className = 'dt-center'))
+    )
+  )
+})
+
+# Section displayed only for authorized users.
+output$admins_view <- renderUI({
+  tagList(
+    tags$section(
+      br(), br(),
+      box(width = 12, collapsible = TRUE, status = "primary",
+          title = h3("View/Change Weights", style = "margin-top: 5px"),
+          solidHeader = TRUE,
+          br(), br(), br(),
+          fluidRow(
+            column(width = 4,
+                   h3("Update weights"),
+                   selectInput("metric_name", "Select metric", metrics_weight()$name, selected = metrics_weight()$name[1]),
+                   numericInput("metric_weight", "Choose new weight", min = 0, value = metrics_weight()$weight[1]),
+                   actionButton("update_weight", "Update weight")),
+            column(width = 8,
+                   h3("View/select metrics"),
+                   dataTableOutput("weights_table"))
+          ),
+          fluidRow(
+            column(width = 12, 
+                   h5(em("Note: Changing the weights of the metrics will not update the
+               risk of the packages on the database. Assessments of 
+               future packages will use these new weights.
+               ")))
+          )
+      )
+    )
+  )
+})
+
+# Update metric weight dropdown so that it matches the metric name.
+observeEvent(input$metric_name, {
+  # Display the weight of the selected metric.
+  updateNumericInput(session, "metric_weight",
+                     value = metrics_weight() %>%
+                       filter(name == input$metric_name) %>%
+                       select(weight) %>%
+                       pull())
+})
+
+# Update metric name dropdown based on the selected row on the table.
+# Note that another of the observeEvents will update the metric weight after
+# the selected metric name is updated.
+observeEvent(input$weights_table_rows_selected, {
+  updateSelectInput(session, "metric_name",
+                     selected = metrics_weight()$name[input$weights_table_rows_selected])
+})
+
+
+
+# Save new weight into db.
+observeEvent(input$update_weight, {
+  validate(
+    need(is.numeric(input$metric_weight), "Please select a valid numeric weight.")
+  )
+  
+  update_metric_weight(input$metric_name, input$metric_weight)
+})

--- a/Server/db_dash_screen.R
+++ b/Server/db_dash_screen.R
@@ -179,6 +179,7 @@ output$admins_view <- renderUI({
                    h3("View/select metrics"),
                    dataTableOutput("weights_table"))
           ),
+          br(),
           fluidRow(
             column(width = 12, 
                    h5(em("Note: Changing the weights of the metrics will not update the

--- a/Server/uploadpackage.R
+++ b/Server/uploadpackage.R
@@ -30,18 +30,16 @@ steps <- reactive(
 observeEvent(input$help,
              introjs(session,
                      options = list(steps = steps(),
-                                    "nextLabel"="Next",
-                                    "prevLabel"="Previous",
-                                    "skipLabel"="Skip"
+                                    "nextLabel" = "Next",
+                                    "prevLabel" = "Previous",
+                                    "skipLabel" = "Close"
                      )
              )
 )
 
-# Reactive variable to load the sample csv file into data().
+# Sample csv file content.
 data <- reactive({
-  data1<-read_csv("./Data/upload_format.csv")
-  data1<-data.table(data1)
-  data1
+  data.table(read_csv(file.path("Data", "upload_format.csv")))
 })
 
 # Load the columns from DB into reactive values.
@@ -186,7 +184,7 @@ output$total_new_undis_dup_table <- DT::renderDataTable({
 }) # End of the render Output 
 # End of the Render Output's'.
 
-# Observe Event for view sample dataset button.
+# View sample dataset
 observeEvent(input$upload_format, {
   dataTableOutput("sampletable")
   showModal(modalDialog(

--- a/UI/assessment_criteria.R
+++ b/UI/assessment_criteria.R
@@ -19,7 +19,7 @@ showModal(tags$div(id = "assessment_criteria_id", modalDialog(
       value = "tab_1",
       tags$b("Maintenance Metrics", class = "txt-color"),
       h3("Description"),
-      htmlOutput("maintenance_desc"),  # html output for maintenance metrics content.  
+      uiOutput("maintenance_desc"),  # Maintenance metrics description.
       br(),
       dataTableOutput("maintenance_table")  # data table for maintenance metrics. 
     ),

--- a/UI/db_dash_screen.R
+++ b/UI/db_dash_screen.R
@@ -43,6 +43,9 @@ output$screen <- renderUI({
                     selectInput("report_formats", "Select Format", c("html", "docx"))
                   )
                 )
-              )))))
+              ))),
+        br(), br(),
+        uiOutput("admins_view")
+      ))
   )
 })

--- a/UI/uploadpackage.R
+++ b/UI/uploadpackage.R
@@ -15,9 +15,9 @@ output$upload_package <- renderUI({
     class = "u_p_main_row",
     tags$div(class = "row col-sm-12 u_p_heading_row",
              tags$h2("Upload list of R Packages"),
-             actionBttn("help", "Need help?", color = "success",
-                        icon = icon("star-of-life"),
-                        block = FALSE, style = "bordered", size = "sm")
+             actionBttn("help", "Need help?", color = "primary",
+                        icon = icon("far fa-star"),
+                        block = FALSE, style = "simple", size = "sm")
     ),
     fluidRow(
       style = "text-align: left;",

--- a/Utils/sql_queries/initialize_metric_table.sql
+++ b/Utils/sql_queries/initialize_metric_table.sql
@@ -8,4 +8,6 @@ INSERT INTO metric (name, description, class, weight) values
 ('has_source_control', '', 'maintenance', 1),
 ('export_help', '', 'maintenance', 1),
 ('bugs_status', '', 'maintenance', 1),
-('covr_coverage', '', 'test', 1);
+('license', '', 'maintenance', 1),
+('covr_coverage', '', 'test', 1),
+('downloads_1yr', '', 'community', 1);

--- a/Utils/utils.R
+++ b/Utils/utils.R
@@ -124,7 +124,7 @@ get_metric_weights <- function(){
 update_metric_weight <- function(metric_name, metric_weight){
   db_ins(paste0(
     "UPDATE metric ",
-    "SET weight = ", "'", metric_weight, "'", " ",
+    "SET weight = ", metric_weight, " ",
     "WHERE name = ", "'", metric_name, "'"
   ))
 }

--- a/Utils/utils.R
+++ b/Utils/utils.R
@@ -112,25 +112,19 @@ update_db_dash <- function(){
   )
 }
 
-#' Function taken from formattable and modified for the risk assessment app.
-#' Normalize a vector to fit zero-to-one scale
-#'
-#' @param x a numeric vector
-#' @param min numeric value. The lower bound of the interval to normalize \code{x}.
-#' @param max numeric value. The upper bound of the interval to normalize \code{x}.
-#' @param na.rm a logical indicating whether missing values should be removed
-#' @export
-#' @examples
-#' normalize(mtcars$mpg)
-normalize <- function(x, min = 0, max = 1, na.rm = FALSE) {
-  if (all(is.na(x))) return(rep(0, length(x)))
-  if (!is.numeric(x)) stop("x must be numeric")
-  x <- unclass(x)
-  if (min > max) stop("min <= max must be satisfied")
-  if (all(x == 0, na.rm = na.rm)) return(x)
-  xmax <- 1
-  xmin <- 0
-  if (xmax == xmin) return(rep(1, length(x)))
-  min + (max - min) * (x - xmin) / (xmax - xmin)
+# Get each metric's weight.
+get_metric_weights <- function(){
+  db_fun(
+    "SELECT name, weight
+    FROM metric"
+  )
 }
-  
+
+# Update metric's weight.
+update_metric_weight <- function(metric_name, metric_weight){
+  db_ins(paste0(
+    "UPDATE metric ",
+    "SET weight = ", "'", metric_weight, "'", " ",
+    "WHERE name = ", "'", metric_name, "'"
+  ))
+}

--- a/www/main.css
+++ b/www/main.css
@@ -1345,3 +1345,8 @@ i.fas.fa-info-database.fa-2x.database-help-icon:hover {
 #db_pkgs:hover {
   cursor: pointer;
 }
+
+/* Change appearance of introjs help button */
+#help {
+  background-color: #49a0f2;
+}


### PR DESCRIPTION
Created a new section on the database view (database icon page) that contains a table and two dropdown inputs to update the weights. This new section is in a new uiOutput so that we can later show it only for authorized users.

Based on todays meeting, these are some of the items we discussed:
- [ ] Is the UI easy to understand? Any improvements in this direction?
- [ ] We should add documentation on how the weights are calculated. After you guys review it, we can discuss what were your main concerns and have them into account when constructing the documentation.
- [ ] Should we (can we?) move this UI to the shinymanagers admin view?
- [ ] The weights of each metric should be displayed on the tabs and the final report (and in a table on the db view?).