### PR TITLE
Risk calculation info

### DIFF
--- a/Server/assessment_criteria.R
+++ b/Server/assessment_criteria.R
@@ -40,7 +40,7 @@ output$riskcalc_weights_table <- DT::renderDataTable({
     options = list(
       searching = FALSE,
       lengthChange = FALSE,
-      pageLength = 10,
+      pageLength = 15,
       columnDefs = list(list(className = 'dt-center', targets = 1:2))
     )
   )
@@ -66,14 +66,14 @@ output$maintenance_desc <- renderUI({
 # Render table for Maintenance Metrics.
 output$maintenance_table <- DT::renderDataTable(
   datatable(
-    read_csv(file.path("Data", "maintenance.csv")),
+    suppressMessages(read_csv(file.path("Data", "maintenance.csv"))),
     escape = FALSE,
     class = "cell-border",
     selection = 'none',
     options = list(
       sScrollX = "100%",
       aLengthMenu = list(c(5, 10, 20, 100,-1), list('5', '10', '20', '100', 'All')),
-      iDisplayLength = 5
+      iDisplayLength = 15
     )
   )
 )
@@ -89,14 +89,14 @@ output$community_usage_desc <- renderText({
 # Render table for Community Usage Metrics.
 output$community_usage_table <- DT::renderDataTable(
   datatable(
-    read_csv(file.path("Data", "community.csv")),
+    suppressMessages(read_csv(file.path("Data", "community.csv"))),
     escape = FALSE,
     class = "cell-border",
     selection = 'none',
     options = list(
       sScrollX = "100%",
       aLengthMenu = list(c(5, 10, 20, 100,-1), list('5', '10', '20', '100', 'All')),
-      iDisplayLength = 5
+      iDisplayLength = 15
     )
   )
 )

--- a/Server/assessment_criteria.R
+++ b/Server/assessment_criteria.R
@@ -5,6 +5,50 @@
 # License: MIT License
 ###############################################################################
 
+
+riskcalc_text <- "<h4>Per the <b>riskmetric</b> package, there 
+are a series of metrics underlying the risk calculation for any 
+given package. The short-hand names for each metric are 
+listed below with more detail provided on consecutive tabs.
+To calculate a packages overall risk, 
+each metric is assigned a quantitative value: the yes/no metrics (like 
+<b>has_bug_reports_url</b>) recieve a 0 if 'no'
+or a 1 if 'yes', while the quantitative metrics (like <b>bugs_status</b>'s percentage) 
+remain as-is. Since a metric's
+importance is subjective,  weights are applied to put more/less emphasis
+on how certain metrics contribute to the over risk score.
+The weights below were set by this app's admin(s) and are standardized so 
+that each is between 0 and 1, and when summed, 
+equal 1. The risk of a package will be determined by 1 - sum(metric's
+numeric value <b>x</b> standardized weight)</h4>"
+
+# Display the Maintenance Metrics description.
+output$riskcalc_desc <- renderUI({
+  HTML(riskcalc_text)
+})
+
+# Render table for Maintenance Metrics.
+output$riskcalc_weights_table <- DT::renderDataTable({
+  d <- get_metric_weights() %>%
+    formattable() %>%
+    mutate(standardized_weight = weight / sum(weight, na.rm = TRUE))
+  # tot <- data.frame(name = "Column Sums", weight = sum(d$weight, na.rm = T),
+  #                   standardized_weight = round(sum(d$standardized_weight, na.rm = T)), 4)
+  # print(names(d))
+  # DT::datatable(d %>% union(tot),
+  as.datatable(d,
+    selection = list(mode = 'single'),
+    colnames = c("Metric Name", "Admin Weight", "Standardized Weight"),
+    rownames = FALSE,
+    options = list(
+      searching = FALSE,
+      lengthChange = FALSE,
+      pageLength = 10,
+      columnDefs = list(list(className = 'dt-center', targets = 1:2))
+    )
+  )
+})
+
 maintenance_metrics_text <- "<h4>Best practices in software development and
 maintenance can significantly reduce the potential for bugs / errors.
 Package maintainers are not obliged to share their practices (and rarely do),
@@ -14,6 +58,7 @@ metrics based on the white paper
 <a target='_blank' href='https://www.pharmar.org/presentations/r_packages-white_paper.pdf'>
 A Risk-based Approach for Assessing R package Accuracy within a Validated
 Infrastructure</a>.</h4>"
+
 
 # Display the Maintenance Metrics description.
 output$maintenance_desc <- renderUI({

--- a/Server/assessment_criteria.R
+++ b/Server/assessment_criteria.R
@@ -32,10 +32,7 @@ output$riskcalc_weights_table <- DT::renderDataTable({
   d <- get_metric_weights() %>%
     formattable() %>%
     mutate(standardized_weight = weight / sum(weight, na.rm = TRUE))
-  # tot <- data.frame(name = "Column Sums", weight = sum(d$weight, na.rm = T),
-  #                   standardized_weight = round(sum(d$standardized_weight, na.rm = T)), 4)
-  # print(names(d))
-  # DT::datatable(d %>% union(tot),
+
   as.datatable(d,
     selection = list(mode = 'single'),
     colnames = c("Metric Name", "Admin Weight", "Standardized Weight"),

--- a/UI/assessment_criteria.R
+++ b/UI/assessment_criteria.R
@@ -15,6 +15,16 @@ showModal(tags$div(id = "assessment_criteria_id", modalDialog(
   tabsetPanel(
     id = "assessment_criteria_tabs_id",
     tabPanel(
+      id = "tab0",
+      value = "tab_0",
+      tags$b("Risk Calculation", class = "txt-color"),
+      h3("Description"),
+      uiOutput("riskcalc_desc"),  # Maintenance metrics description.
+      br(),
+      div(style = "display: block;margin-left: auto; margin-right: auto; width:50%;",
+        dataTableOutput("riskcalc_weights_table"))  # data table for maintenance metrics.
+    ),
+    tabPanel(
       id = "tab1",
       value = "tab_1",
       tags$b("Maintenance Metrics", class = "txt-color"),

--- a/www/main.css
+++ b/www/main.css
@@ -776,8 +776,8 @@ width: 85%;
 }
 
 #assessment_criteria_id .tab-content { 
-height: 633px; 
-max-height: 633px; 
+height: 655px; 
+max-height: 655px; 
 padding-right: 50px; 
 overflow: auto; 
 margin-top: 0px


### PR DESCRIPTION
Closes #72.

Added tab to `assessment criteria` modal regarding how a package receives it's risk calculation. Specifically, click this:

![image](https://user-images.githubusercontent.com/17878953/119564321-a5c6ec80-bd76-11eb-9631-2655744a9409.png)

And you'll see this:

![image](https://user-images.githubusercontent.com/17878953/119564614-f9393a80-bd76-11eb-86fe-6339ec913bc8.png)

Had to dive into some `riskmetric` code to confirm, but it looks good. Unfortunately, the `riskmetric` team didn't spell this out in their documentation, otherwise I'd link to the exported function called [summarize_scores()](https://pharmar.github.io/riskmetric/reference/summarize_scores.html)

Does this look okay? This will be a nice spot for non-admin folks to see what the admin-assigned weights are currently.

