### PR TITLE
Make Pkg Risk Score more visible

### DIFF
--- a/Server/db_dash_screen.R
+++ b/Server/db_dash_screen.R
@@ -16,14 +16,6 @@ output$db_pkgs <- DT::renderDataTable({
     mutate(was_decision_made = ifelse(decision != "-", TRUE, FALSE)) %>%
     select(name, version, score, was_decision_made, decision, last_comment)
   
-  # https://www.rapidtables.com/web/color/html-color-codes.html
-  low_risk_color  <- "#228B22"  # forest green
-  med_risk_color  <- "#d1b000"  # dark gold
-  high_risk_color <- "#B22222"  # firebrick
-  
-  colfunc <- colorRampPalette(c(low_risk_color, med_risk_color, high_risk_color))
-  # plot(rep(1,100),col=colfunc(100),pch=19,cex=3)
-  
   as.datatable(
     formattable(
       values$db_pkg_overview,

--- a/Server/sidebar.R
+++ b/Server/sidebar.R
@@ -75,40 +75,74 @@ output$sel_ver <- renderUI({
 })
 
 
+
+
+
+
+
 # Display the review status of the selected package.
+
 output$status <- renderUI({
-  if (!is.null(input$select_pack)) {
-    
-    # Defaults to NA.
-    status_output <- "NA"
-    
-    if (input$select_pack != "Select") {
-        status_output <- ifelse(
-          values$selected_pkg$decision == "",
-          "Under Review",
-          "Reviewed")
-    }
-    
-    h3("Status:", strong(status_output))
-  }
+  req(input$select_pack)
+    # status_output <-
+      if(input$select_pack == "Select"){
+        h1(strong("NA"))
+      } else {
+        if(values$selected_pkg$decision == ""){
+          h3("Under Review")
+        } else {
+          h2("Reviewed")
+        }
+      }
 })
+
+
+# # change the color of the wellPanel
+# # observeEvent(list(input$select_pack, values$selected_pkg$decision), {
+# observe({
+#   req(input$select_pack)
+#   print(values$selected_pkg$decision)
+#   print(".")
+#   low_risk_color  <- "#228B22"  # dodger blue
+#   na_risk_color  <- "#C0C0C0"   # silver
+#   if(input$select_pack == "Select"){
+#     valBoxColorStatus <- na_risk_color
+#   } else {
+#     if(values$selected_pkg$decision == ""){
+#       valBoxColorStatus <- na_risk_color
+#     } else {
+#       valBoxColorStatus <- low_risk_color
+#     }
+#   }
+#   runjs(sprintf("
+#             document.getElementById('%s').style.backgroundColor = '%s';
+#         ", "diyValBoxStatus", valBoxColorStatus))
+#   print(valBoxColorStatus)
+# })
 
 # Required for shinyhelper to work.
 observe_helpers()
 
 # Display the risk score of the selected package.
 output$score <- renderUI({
-  if (!is.null(input$select_pack)) {
+  req(input$select_pack)
     
-    # Score defaults to NA.
-    score_output <- "NA"
-    
-    # If a package is selected, then display the package score.
-    if(input$select_pack != "Select")
-      score_output <- values$selected_pkg$score
+  # Score defaults to NA.
+  score_output <- ifelse(input$select_pack != "Select", values$selected_pkg$score, "NA")
+  h1(strong(score_output))
+})
 
-      h3("Score:", strong(score_output))
-}})
+# change the color of the wellPanel
+observe({
+  req(input$select_pack)
+  score_output_num <- ifelse(input$select_pack != "Select", values$selected_pkg$score, NA_integer_)
+  valBoxColor <- ifelse(is.na(score_output_num), "#1E90FF", colfunc(100)[round(as.numeric(score_output_num)*100)])
+  runjs(sprintf("
+            document.getElementById('%s').style.backgroundColor = '%s';
+        ", "diyValBoxScore", valBoxColor))
+})
+
+
 
 # 1. Observe Event for select package
 observeEvent(input$select_pack, {

--- a/Server/sidebar.R
+++ b/Server/sidebar.R
@@ -97,28 +97,6 @@ output$status <- renderUI({
 })
 
 
-# # change the color of the wellPanel
-# # observeEvent(list(input$select_pack, values$selected_pkg$decision), {
-# observe({
-#   req(input$select_pack)
-#   print(values$selected_pkg$decision)
-#   print(".")
-#   low_risk_color  <- "#228B22"  # dodger blue
-#   na_risk_color  <- "#C0C0C0"   # silver
-#   if(input$select_pack == "Select"){
-#     valBoxColorStatus <- na_risk_color
-#   } else {
-#     if(values$selected_pkg$decision == ""){
-#       valBoxColorStatus <- na_risk_color
-#     } else {
-#       valBoxColorStatus <- low_risk_color
-#     }
-#   }
-#   runjs(sprintf("
-#             document.getElementById('%s').style.backgroundColor = '%s';
-#         ", "diyValBoxStatus", valBoxColorStatus))
-#   print(valBoxColorStatus)
-# })
 
 # Required for shinyhelper to work.
 observe_helpers()

--- a/Server/sidebar.R
+++ b/Server/sidebar.R
@@ -110,6 +110,19 @@ output$score <- renderUI({
   h1(strong(score_output))
 })
 
+# change the color of the status wellPanel
+observe({
+  req(input$select_pack)
+  valBoxColor <- case_when(
+    input$select_pack == "Select" ~ "white",
+    !is_empty(values$selected_pkg$decision) && values$selected_pkg$decision == "" ~ "black",
+    TRUE ~ "blue"
+  )
+  runjs(sprintf("
+                document.getElementById('%s').style.color = '%s';
+                ", "diyValBoxStatus", valBoxColor))
+})
+
 # change the color of the wellPanel
 observe({
   req(input$select_pack)

--- a/Server/sidebar.R
+++ b/Server/sidebar.R
@@ -96,6 +96,18 @@ output$status <- renderUI({
       }
 })
 
+# change the color of the status wellPanel's font
+observe({
+  req(input$select_pack)
+  valBoxColor <- case_when(
+    input$select_pack == "Select" ~ "white",
+    !is_empty(values$selected_pkg$decision) && values$selected_pkg$decision == "" ~ "black",
+    TRUE ~ "darkblue"
+  )
+  runjs(sprintf("
+                document.getElementById('%s').style.color = '%s';
+                ", "diyValBoxStatus", valBoxColor))
+})
 
 
 # Required for shinyhelper to work.
@@ -110,18 +122,7 @@ output$score <- renderUI({
   h1(strong(score_output))
 })
 
-# change the color of the status wellPanel
-observe({
-  req(input$select_pack)
-  valBoxColor <- case_when(
-    input$select_pack == "Select" ~ "white",
-    !is_empty(values$selected_pkg$decision) && values$selected_pkg$decision == "" ~ "black",
-    TRUE ~ "blue"
-  )
-  runjs(sprintf("
-                document.getElementById('%s').style.color = '%s';
-                ", "diyValBoxStatus", valBoxColor))
-})
+
 
 # change the color of the wellPanel
 observe({

--- a/UI/dashboard_screen.R
+++ b/UI/dashboard_screen.R
@@ -27,8 +27,24 @@ output$screen <- renderUI({
                    width = 12,
                    uiOutput("sel_pack"), # UI for select package.
                    uiOutput("sel_ver"), # UI for version of the selected package.
-                   uiOutput("status"), # Display the status of the package.
-                   uiOutput("score"), # Display the score of the package.
+                   # uiOutput("status"), # Display the status of the package.
+                   fixedRow(
+                     column(6, wellPanel(
+                       id = "diyValBoxStatus",
+                       style = "height: 150px; border-radius: 25px; border-style: dotted; background-color: #C0C0C0 !important; color: #FFFFFF !important;",
+                       uiOutput("status"), # Display the score of the package.
+                       h3("Status")
+                     )),
+                     column(6, wellPanel(
+                       id = "diyValBoxScore",
+                       style = "height: 150px; border-radius: 25px; border-style: dotted; background-color: #1E90FF !important; color: #FFFFFF !important;",
+                       uiOutput("score"), # Display the score of the package.
+                       h3("Risk Score")
+                       # shinydashboard::valueBoxOutput("score", width = 12),
+                     ))
+                   ),
+                   
+                   
                    textAreaInput(
                      "overall_comment",
                      h3("Leave Your Overall Comment:"),

--- a/Utils/utils.R
+++ b/Utils/utils.R
@@ -5,6 +5,14 @@
 # License: MIT License
 #####################################################################################################################
 
+# function defined to provide consistent risk color palettes across multiple "modules"
+# https://www.rapidtables.com/web/color/html-color-codes.html
+low_risk_color  <- "#228B22"  # forest green
+med_risk_color  <- "#d1b000"  # dark gold
+high_risk_color <- "#B22222"  # firebrick
+colfunc <- colorRampPalette(c(low_risk_color, med_risk_color, high_risk_color))
+
+
 # Stores the database name.
 db_name <- "database.sqlite"
 


### PR DESCRIPTION
Closes #71.

I made my own version of a `shinydashboard::valueBox()` as I found it quite inflexible. I also made sure the color of the `wellPanel()` mimics that which is found on the `db_dash_screen`. Thoughts?

![image](https://user-images.githubusercontent.com/17878953/119711965-1b41c400-be2e-11eb-9d6f-09919301ce06.png)

![image](https://user-images.githubusercontent.com/17878953/119711906-0b29e480-be2e-11eb-9959-58b1e52691cf.png)

![image](https://user-images.githubusercontent.com/17878953/119711852-fc433200-be2d-11eb-8fec-cd980335a35a.png)

