### PR TITLE
Expand help

### DIFF
--- a/Server/communityusage_metrics.R
+++ b/Server/communityusage_metrics.R
@@ -6,6 +6,38 @@
 #####################################################################################################################
 
 
+# Implement the intro logic. Sidebar steps are listed in global.r
+# this dataset is also static... perhaps it should be sourced from global.r?
+cum_steps <- reactive(
+  data.frame(
+    # Note that we access chooseCSVtext with '.' instead of '#', because we track its class and not its id.
+    element = c("#cum_infoboxes", "#cum_plot", "#cum_add_comment", "#cum_prev_comments"),
+    intro = c(
+      "Several ways of measuring cummunity usage assessed here. Please review!",
+      "Digest downloads per month by selecting a pre-defined time periods or toggling the date slider at bottom of plot for custom date range",
+      "Have something to share within your organization? Add a comment.",
+      "Keep track of the on-going conversation for this package's community usage"
+    ),
+    position = c("bottom", rep("top", 3))
+  )
+)
+
+
+# Start introjs when help button is pressed.
+observeEvent(input$help_cum,
+             introjs(session,
+                     options = list(
+                       steps = 
+                         cum_steps() %>%
+                         union(sidebar_steps),
+                       "nextLabel" = "Next",
+                       "prevLabel" = "Previous",
+                       "skipLabel" = "Close"
+                     )
+             )
+)
+
+
 # Start of the observe's'
 
 # 1. Observe to load the columns from DB into reactive values.

--- a/Server/maintenance_metrics.R
+++ b/Server/maintenance_metrics.R
@@ -5,6 +5,35 @@
 # Date: June 13th, 2020
 #####################################################################################################################
 
+# Implement the intro logic. Sidebar steps are listed in global.r
+# this dataset is also static... perhaps it should be sourced from global.r?
+mm_steps <- reactive(
+  data.frame(
+    # Note that we access chooseCSVtext with '.' instead of '#', because we track its class and not its id.
+    element = c("#mm_infoboxes", "#mm_add_comment", "#mm_prev_comments"),
+    intro = c(
+      "Several ways of measuring package maintenance best practices are assessed here. Please review!",
+      "Have something to share within your organization? Add a comment.",
+      "Keep track of the on-going conversation for this package's maintainence metrics"
+    ),
+    position = c(rep("top", 3))
+  )
+)
+
+
+# Start introjs when help button is pressed.
+observeEvent(input$help_mm,
+   introjs(session,
+     options = list(
+       steps = 
+         mm_steps() %>%
+         union(sidebar_steps),
+       "nextLabel" = "Next",
+       "prevLabel" = "Previous",
+       "skipLabel" = "Close"
+     )
+   )
+)
 
 # Save each metric information into variables.
 observe({

--- a/Server/reportpreview.R
+++ b/Server/reportpreview.R
@@ -5,6 +5,41 @@
 # License: MIT License
 #####################################################################################################################
 
+
+
+
+
+# Implement the intro logic. Sidebar steps are listed in global.r
+# this dataset is also static... perhaps it should be sourced from global.r?
+rp_steps <- reactive(
+  data.frame(
+    # Note that we access chooseCSVtext with '.' instead of '#', because we track its class and not its id.
+    element = c( "#dwnld_rp", "#rep_prev"),
+    intro = c(
+      "Select file output type for report seen below and download for later use",
+      "The current assessment of this package including your comments and overall decision have been collected from the other tabs to prepare the following report for convenience."
+    ),
+    position = c("left", "top")
+  )
+)
+
+
+# Start introjs when help button is pressed.
+observeEvent(input$help_rp,
+             introjs(session,
+                     options = list(
+                       steps = 
+                         rp_steps() %>%
+                         union(sidebar_steps),
+                       "nextLabel" = "Next",
+                       "prevLabel" = "Previous",
+                       "skipLabel" = "Close"
+                     )
+             )
+)
+
+
+
 #Start of the Render Output's'
 
 # 1. Render Output to display the general information of the selected package.

--- a/Server/uploadpackage.R
+++ b/Server/uploadpackage.R
@@ -5,36 +5,49 @@
 # License: MIT License
 #####################################################################################################################
 
-# Implement the intro logic.
-steps <- reactive(
+# Implement the intro logic. Sidebar steps are listed in global.r
+# this dataset is also static... perhaps it should be sourced from global.r?
+upload_pkg_initial_steps <- reactive(
   data.frame(
     # Note that we access chooseCSVtext with '.' instead of '#', because we track its class and not its id.
-    element = c("#help", ".chooseCSVtext", ".sample_dataset_link", "#sel_pack", "#sel_ver",
-                "#status", "#score", "#overall_comment", "#decision"),
+    element = c("#help", ".chooseCSVtext", ".sample_dataset_link"),
     intro = c(
       "Click here anytime you need help.",
       "Upload a CSV file with the package(s) you would like to assess.",
-      "You can use this sample dataset to explore the app.",
-      "Once you upload your packages, click this dropdown to choose one.",
-      "The latest package version will autopopulate here.",
-      "The status can be either 'Under Review' or 'Reviewed'.",
-      "The score can take any value between 0 (e.g., no risk) and 1 (e.g., highest risk).",
-      "After reviewing your package, you can leave an overall comment.",
-      "Use this slider to provide your take on the overall risk of the selected package."
+      "You can use this sample dataset to explore the app."
     ),
-    position = c("right", rep("top", 3), rep("bottom", 5))
+    position = c("right", rep("top", 2))
   )
+)
+upload_pkg_steps <- reactive(
+  if(values$upload_complete == "upload_complete"){
+    data.frame(
+      element = c("#upload_summary_text", "#upload_summary"),
+      intro = c(
+        "Text description of packages uploaded. Counts by type: 'Total', 'New', 'Undiscovered', 'Duplicate'.",
+        "Confirm uploaded packages list, filter by type"
+      ),
+      position = c("bottom", "top")
+    )
+  } else {
+    data.frame(element = character(0) , intro = character(0), position = character(0))
+  }
+
 )
 
 # Start introjs when help button is pressed.
 observeEvent(input$help,
-             introjs(session,
-                     options = list(steps = steps(),
-                                    "nextLabel" = "Next",
-                                    "prevLabel" = "Previous",
-                                    "skipLabel" = "Close"
-                     )
-             )
+   introjs(session,
+     options = list(
+       steps = 
+          upload_pkg_initial_steps() %>%
+          union(upload_pkg_steps()) %>%
+          union(sidebar_steps),
+        "nextLabel" = "Next",
+        "prevLabel" = "Previous",
+        "skipLabel" = "Close"
+     )
+   )
 )
 
 # Sample csv file content.

--- a/UI/communityusage_metrics.R
+++ b/UI/communityusage_metrics.R
@@ -16,52 +16,64 @@ output$community_usage_metrics <- renderUI({
   if (!is.null(values$packsDB$name) &&
       !identical(values$packsDB$name, character(0))) {
     if (input$select_pack != "Select") {
-      fluidRow(
-        div(style = "height:25px;"),
-        class = "c_u_m_row_main",
+      shiny::tagList(
+        br(),
+        div(class = "row col-sm-12 u_p_heading_row",
+            actionBttn("help_cum", "Need help?", color = "primary",
+                       icon = icon("far fa-star"),
+                       block = FALSE, style = "simple", size = "sm")),
+        br(), br(),
         fluidRow(
-          class = "c_u_m_row_1",
-          infoBoxOutput("time_since_first_release", width = 4),  # Info box to show the time since First release.
-          infoBoxOutput("time_since_version_release", width = 4),  # Info box to show the time since version release.
-          infoBoxOutput("dwnlds_last_yr", width = 4)  # Info box to show the total # of Downloads in the last year.
-        ),
-        fluidRow(
-          class = "c_u_m_row_graph",
-          column(width = 1, ),
-          column(width = 10,
-                 class = "w-90",
-                 plotly::plotlyOutput("no_of_downloads")
-                 ),
-          column(width = 1, )
-        ),
-        
-        fluidRow(
-          class = "c_u_m_row_comments_box",
-          column(
-            
-            width = 8,
-            class = "mb-4 label-float-left",
-            # Text box to leave community usage metrics comments.
-            textAreaInput(
-              "cum_comment",
-              h3(tags$b("Leave Your Comment for Community Usage Metrics:")),
-              width = "100%",
-              rows = 4,
-              placeholder = paste("Commenting as", values$name, "(", values$role, ")")
-            ) %>%
-              shiny::tagAppendAttributes(style = 'width: 100%;'),
-            # Action button to submit the comments.
-            actionButton("submit_cum_comment", class = "submit_cum_comment_class btn-secondary", "Submit")
-          )
-        ),
-        fluidRow(
-          class = "c_u_m_row_comments",
-          column(
-            width = 12,
-            align = "left",
-            h3(tags$b(paste0('Comments(',nrow(values$comment_cum2),'):'))),
-            htmlOutput("cum_commented")  # html output to show the comments on applicaiton.
-          ))
+          div(style = "height:25px;"),
+          class = "c_u_m_row_main",
+          fluidRow(
+            id = "cum_infoboxes",
+            class = "c_u_m_row_1",
+            infoBoxOutput("time_since_first_release", width = 4),  # Info box to show the time since First release.
+            infoBoxOutput("time_since_version_release", width = 4),  # Info box to show the time since version release.
+            infoBoxOutput("dwnlds_last_yr", width = 4)  # Info box to show the total # of Downloads in the last year.
+          ),
+          fluidRow(
+            id = "cum_plot",
+            class = "c_u_m_row_graph",
+            column(width = 1, ),
+            column(width = 10,
+                   class = "w-90",
+                   plotly::plotlyOutput("no_of_downloads")
+                   ),
+            column(width = 1, )
+          ),
+          
+          fluidRow(
+            id = "cum_add_comment",
+            class = "c_u_m_row_comments_box",
+            column(
+              
+              width = 8,
+              class = "mb-4 label-float-left",
+              # Text box to leave community usage metrics comments.
+              textAreaInput(
+                "cum_comment",
+                h3(tags$b("Leave Your Comment for Community Usage Metrics:")),
+                width = "100%",
+                rows = 4,
+                placeholder = paste("Commenting as", values$name, "(", values$role, ")")
+              ) %>%
+                shiny::tagAppendAttributes(style = 'width: 100%;'),
+              # Action button to submit the comments.
+              actionButton("submit_cum_comment", class = "submit_cum_comment_class btn-secondary", "Submit")
+            )
+          ),
+          fluidRow(
+            id = "cum_prev_comments",
+            class = "c_u_m_row_comments",
+            column(
+              width = 12,
+              align = "left",
+              h3(tags$b(paste0('Comments(',nrow(values$comment_cum2),'):'))),
+              htmlOutput("cum_commented")  # html output to show the comments on applicaiton.
+            ))
+        )
       )
     } 
     # Show the select the package message if user not selected any package from dropdown in the application. 

--- a/UI/maintenance_metrics.R
+++ b/UI/maintenance_metrics.R
@@ -15,52 +15,64 @@ output$maintenance_metrics <- renderUI({
   if (!is.null(values$packsDB$name) &&
       !identical(values$packsDB$name, character(0))) {
     if (input$select_pack != "Select") {
-      fluidRow(
-        div(style = "height:25px;"),
-        class = "mm-main-row",
+      shiny::tagList(
+        br(),
+        div(class = "row col-sm-12 u_p_heading_row",
+                 actionBttn("help_mm", "Need help?", color = "primary",
+                   icon = icon("far fa-star"),
+                   block = FALSE, style = "simple", size = "sm")),
+        br(), br(),
         fluidRow(
-          class = "mm-row-1",
-          infoBoxOutput("has_vignettes"),  # Info box for 'has_vignettes' metric.
-          infoBoxOutput("has_website"),  # Info box for 'has_website' metric.
-          infoBoxOutput("has_news"),  # Info box for 'has_news' metric.
-        ),
-        fluidRow(
-          class = "mm-row-2",
-          infoBoxOutput("news_current"),  # Info box for 'news_current' metric.
-          infoBoxOutput("has_bug_reports_url"),  # Info box for 'has_bug_reports_url' metric.
-          infoBoxOutput("bugs_status"),  # Info box for 'bugs_status' metric.
-        ),
-        fluidRow(
-          class = "mm-row-3",
-          infoBoxOutput("export_help"),  # Info box for 'export_help' metric.
-          infoBoxOutput("has_source_control"),  # Info box for 'has_source_control' metric.
-          infoBoxOutput("has_maintainer"),  # Info box for 'has_maintainer' metric.
-        ),
-        fluidRow(
-          class = "mm-row-comments-box",
-          column(
-            width = 8,
-            class = "mb-4 label-float-left",
-            # Text input box to leave the Maintenance Metrics Comments.
-            textAreaInput(
-              "mm_comment",
-              h3(tags$b("Leave Your Comment for Maintenance Metrics:")),
-              width = "100%",
-              rows = 4,
-              placeholder = paste("Commenting as", values$name, "(", values$role, ")")
-            ) %>%
-              shiny::tagAppendAttributes(style = 'width: 100%;'),
-            # Action button to submit the comment.
-            actionButton("submit_mm_comment", class = "submit_mm_comment_class btn-secondary", "Submit")
-          )
-        ),
-        fluidRow(
-          class = "mm-row-comments",
-          column(
-            width = 12,
-            align = "left",
-            h3(tags$b(paste0('Comments(',nrow(values$comment_mm2),'):'))),
-            htmlOutput("mm_commented")  # html output to show the comments on application.
+          div(style = "height:25px;"),
+          class = "mm-main-row",
+          div(id = "mm_infoboxes", 
+              fluidRow(
+              class = "mm-row-1",
+              infoBoxOutput("has_vignettes"),  # Info box for 'has_vignettes' metric.
+              infoBoxOutput("has_website"),  # Info box for 'has_website' metric.
+              infoBoxOutput("has_news"),  # Info box for 'has_news' metric.
+            ),
+            fluidRow(
+              class = "mm-row-2",
+              infoBoxOutput("news_current"),  # Info box for 'news_current' metric.
+              infoBoxOutput("has_bug_reports_url"),  # Info box for 'has_bug_reports_url' metric.
+              infoBoxOutput("bugs_status"),  # Info box for 'bugs_status' metric.
+            ),
+            fluidRow(
+              class = "mm-row-3",
+              infoBoxOutput("export_help"),  # Info box for 'export_help' metric.
+              infoBoxOutput("has_source_control"),  # Info box for 'has_source_control' metric.
+              infoBoxOutput("has_maintainer"),  # Info box for 'has_maintainer' metric.
+            )
+          ),
+          fluidRow(
+            id = "mm_add_comment",
+            class = "mm-row-comments-box",
+            column(
+              width = 8,
+              class = "mb-4 label-float-left",
+              # Text input box to leave the Maintenance Metrics Comments.
+              textAreaInput(
+                "mm_comment",
+                h3(tags$b("Leave Your Comment for Maintenance Metrics:")),
+                width = "100%",
+                rows = 4,
+                placeholder = paste("Commenting as", values$name, "(", values$role, ")")
+              ) %>%
+                shiny::tagAppendAttributes(style = 'width: 100%;'),
+              # Action button to submit the comment.
+              actionButton("submit_mm_comment", class = "submit_mm_comment_class btn-secondary", "Submit")
+            )
+          ),
+          fluidRow(
+            id = "mm_prev_comments",
+            class = "mm-row-comments",
+            column(
+              width = 12,
+              align = "left",
+              h3(tags$b(paste0('Comments(',nrow(values$comment_mm2),'):'))),
+              htmlOutput("mm_commented")  # html output to show the comments on application.
+            )
           )
         )
       )

--- a/UI/reportpreview.R
+++ b/UI/reportpreview.R
@@ -15,38 +15,49 @@ output$report_preview<-renderUI({
       !identical(values$packsDB$name, character(0))) {
   if (input$select_pack != "Select") {
     removeUI(selector = "#Upload")
-    fluidRow(
-      class = "mt-4 r_p_main_row",
-      
+    
+    shiny::tagList(
+      br(),
+      div(class = "row col-sm-12 u_p_heading_row",
+          actionBttn("help_rp", "Need help?", color = "primary",
+                     icon = icon("far fa-star"),
+                     block = FALSE, style = "simple", size = "sm")),
+      br(), br(),
       fluidRow(
-        class="float-right r_p_format_row",
-        tags$div(
-          class="col-sm W-40 text-left float-right",
-          selectInput("report_format", "Select Format", c("html", "docx")),  # Select input to select the format for report.
-        ),
-        tags$div(
-          class="col-sm float-right",
-          downloadButton("download_report_btn", "Download Report", class = "download_report_btn_class btn-secondary"),  # Download button to export the report.
-        ),
-      ),
-      fluidRow(
-        column(
-          width = 12,
-          class = "text-left",
-          htmlOutput("gen_info"),  # Display General Information of the selected Package.
-          htmlOutput("decision_display"),  # Display the status of the Decision of a selected Package.
-          h3(tags$b(paste0('Overall Comments(',nrow(values$comment_o2),'):'))),
-          fluidRow(
-            class = "overall-comments-row",
-            column(
-              width = 12,
-              align = "left",
-              htmlOutput("overall_comments")  # Display the overall comment for selected Package. 
-            )
+        class = "mt-4 r_p_main_row",
+        
+        fluidRow(
+          id = "dwnld_rp",
+          class="float-right r_p_format_row",
+          tags$div(
+            class="col-sm W-40 text-left float-right",
+            selectInput("report_format", "Select Format", c("html", "docx")),  # Select input to select the format for report.
           ),
-          source(file.path("UI", "mm_report.R"), local = TRUE)$value,
-          source(file.path("UI", "cum_report.R"), local = TRUE)$value,
-          # source(file.path("UI", "tm_report.R"), local = TRUE)$value
+          tags$div(
+            class="col-sm float-right",
+            downloadButton("download_report_btn", "Download Report", class = "download_report_btn_class btn-secondary"),  # Download button to export the report.
+          ),
+        ),
+        fluidRow(
+          id = "rep_prev",
+          column(
+            width = 12,
+            class = "text-left",
+            htmlOutput("gen_info"),  # Display General Information of the selected Package.
+            htmlOutput("decision_display"),  # Display the status of the Decision of a selected Package.
+            h3(tags$b(paste0('Overall Comments(',nrow(values$comment_o2),'):'))),
+            fluidRow(
+              class = "overall-comments-row",
+              column(
+                width = 12,
+                align = "left",
+                htmlOutput("overall_comments")  # Display the overall comment for selected Package. 
+              )
+            ),
+            source(file.path("UI", "mm_report.R"), local = TRUE)$value,
+            source(file.path("UI", "cum_report.R"), local = TRUE)$value,
+            # source(file.path("UI", "tm_report.R"), local = TRUE)$value
+          )
         )
       )
     )

--- a/UI/uploadpackage.R
+++ b/UI/uploadpackage.R
@@ -43,10 +43,12 @@ output$upload_package <- renderUI({
     fluidRow(
       style = "padding-left: 50px; padding-bottom: 10px",
       column(width = 6,
-             div(class = "row col-sm-12 mb-4 u_p_dropdown_row",
-                 uiOutput("upload_summary_select")),
-             # Display the table with total rows in the DB.
-             dataTableOutput("total_new_undis_dup_table"))
+             div(id = "upload_summary",
+                 div(class = "row col-sm-12 mb-4 u_p_dropdown_row",
+                     uiOutput("upload_summary_select")),
+                 # Display the table with total rows in the DB.
+                 dataTableOutput("total_new_undis_dup_table"))
+      )
     )
   )
 })

--- a/Utils/utils.R
+++ b/Utils/utils.R
@@ -128,3 +128,5 @@ update_metric_weight <- function(metric_name, metric_weight){
     "WHERE name = ", "'", metric_name, "'"
   ))
 }
+
+

--- a/global.R
+++ b/global.R
@@ -51,16 +51,19 @@ source("Utils/infoboxes.R")
 # does this belong in utils or global.r? It is static, and non-functional
 sidebar_steps <-
   data.frame(
-    element = c("#sel_pack", "#sel_ver","#status", "#score", "#overall_comment", "#decision"),
+    element = c("#assessment_criteria_bttn", "#db_dash_bttn", "#sel_pack", "#sel_ver",
+                "#status", "#score", "#overall_comment", "#decision"),
     intro = c(
-      "Click this dropdown to select a package one.",
+      "Click here to understand the package assessment process & criteria",
+      "See an overview of the R packages that already exist in the database",
+      "Click this dropdown to select assess a specific package",
       "The latest package version will autopopulate here.",
       "The status can be either 'Under Review' or 'Reviewed'.",
       "The score can take any value between 0 (no risk) and 1 (highest risk).",
       "After reviewing your package, you can leave an overall comment.",
       "Provide your input on the overall risk of the selected package."
     ),
-    position = c(rep("bottom", 6))
+    position = c(rep("left", 2), rep("bottom", 6))
   )
 
 # Note: If deploying the app to shinyapps.io, then the code to directly install

--- a/global.R
+++ b/global.R
@@ -48,6 +48,21 @@ if(!require(riskmetric)){
 # Load the functions to create infoboxes.
 source("Utils/infoboxes.R")
 
+# does this belong in utils or global.r? It is static, and non-functional
+sidebar_steps <-
+  data.frame(
+    element = c("#sel_pack", "#sel_ver","#status", "#score", "#overall_comment", "#decision"),
+    intro = c(
+      "Click this dropdown to select a package one.",
+      "The latest package version will autopopulate here.",
+      "The status can be either 'Under Review' or 'Reviewed'.",
+      "The score can take any value between 0 (no risk) and 1 (highest risk).",
+      "After reviewing your package, you can leave an overall comment.",
+      "Provide your input on the overall risk of the selected package."
+    ),
+    position = c(rep("bottom", 6))
+  )
+
 # Note: If deploying the app to shinyapps.io, then the code to directly install
 # missing packages will need to be removed as the app will fail to deploy.
 # Instead comment the code that install packages and attach them directly by


### PR DESCRIPTION
Closes #127.

I expanded the `introjs` help guide that @marlycormar originally pioneered on the Data Upload tab to include all the tabs, where each tab has it's own `Need Help?` button that runs through all the important objects/inputs on that tab **plus** describes the sidebar inputs **plus** describes some additional buttons that the user should know about (such as the risk criteria modal button & database dashboard button).

I intentionally excluded adding a help button to the database dashboard screen since it's under construction. We can take care of that when the UI elements become more stable like all the other tabs.