### PR TITLE
Use default `skipLabel` for `rintrojs` guide

### DIFF
--- a/Server/uploadpackage.R
+++ b/Server/uploadpackage.R
@@ -44,8 +44,7 @@ observeEvent(input$help,
           union(upload_pkg_steps()) %>%
           union(sidebar_steps),
         "nextLabel" = "Next",
-        "prevLabel" = "Previous",
-        "skipLabel" = "Close"
+        "prevLabel" = "Previous"
      )
    )
 )


### PR DESCRIPTION
One line of code to close #143. Either of you can review and merge when ready.