### PR TITLE
Make output dependent on the "name" column of metrics

### DIFF
--- a/R/metricGrid.R
+++ b/R/metricGrid.R
@@ -17,7 +17,7 @@ metricGridServer <- function(id, metrics) {
     ns <- session$ns
     
     metric_lst <- reactive({
-      metrics()[['name']] %>%
+      metrics()[[1]] %>%
         split(ceiling((3*seq_along(.)-1)/length(.)))
     })
     
@@ -43,6 +43,8 @@ metricGridServer <- function(id, metrics) {
                           value = metric['value'],
                           is_perc = metric['is_perc'] == 1,
                           is_url = metric['is_url'] == 1))
+      } else if (all(c('id', 'title', 'desc', 'value', 'succ_icon', 'icon_class') == names(metrics()))) {
+        pmap(metrics(), metricBoxServer)
       }
     })
   })

--- a/R/metricGrid.R
+++ b/R/metricGrid.R
@@ -4,32 +4,46 @@ metricGridUI <- function(id) {
   fluidPage(
     fluidRow(style = cards_style, class = "card-group",
              column(width = 4,
-                    metricBoxUI(NS(id, "has_vignettes")),
-                    metricBoxUI(NS(id, "news_current")),
-                    metricBoxUI(NS(id, "has_source_control"))),
+                    uiOutput(NS(id, "col1"))),
              column(width = 4,
-                    metricBoxUI(NS(id, "has_maintainer")),
-                    metricBoxUI(NS(id, "has_bug_reports_url")),
-                    metricBoxUI(NS(id, "export_help"))),
+                    uiOutput(NS(id, "col2"))),
              column(width = 4,
-                    metricBoxUI(NS(id, "has_news")),
-                    metricBoxUI(NS(id, "has_website")),
-                    metricBoxUI(NS(id, "bugs_status")))
-    ))
+                    uiOutput(NS(id, "col3")))
+  ))
 }
 
 metricGridServer <- function(id, metrics) {
   moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+    
+    metric_lst <- reactive({
+      metrics()[['name']] %>%
+        split(ceiling((3*seq_along(.)-1)/length(.)))
+    })
+    
+    output$col1 <- renderUI({
+      lapply(metric_lst()[[1]], function(x) metricBoxUI(ns(x)))
+    })
+
+    output$col2 <- renderUI({
+      lapply(metric_lst()[[2]], function(x) metricBoxUI(ns(x)))
+    })
+
+    output$col3 <- renderUI({
+      lapply(metric_lst()[[3]], function(x) metricBoxUI(ns(x)))
+    })
     
     # Create 
     observeEvent(metrics(), {
-      apply(metrics(), 1, function(metric)
-        metricBoxServer(id = metric['name'],
-                        title = metric['long_name'],
-                        desc = metric['description'],
-                        value = metric['value'],
-                        is_perc = metric['is_perc'] == 1,
-                        is_url = metric['is_url'] == 1))
+      if (all(c('name', 'long_name', 'description', 'value', 'is_perc', 'is_url') %in% names(metrics()))) {
+        apply(metrics(), 1, function(metric)
+          metricBoxServer(id = metric['name'],
+                          title = metric['long_name'],
+                          desc = metric['description'],
+                          value = metric['value'],
+                          is_perc = metric['is_perc'] == 1,
+                          is_url = metric['is_url'] == 1))
+      }
     })
   })
 }

--- a/Server/communityusage_metrics.R
+++ b/Server/communityusage_metrics.R
@@ -1,10 +1,11 @@
 # IntroJS.
 introJSServer(id = "cum_introJS", text = cum_steps)
 
-#' Creates three metricBoxes: the time since first release, the time since
-#' latest release, and the number of downloads since last year.
-observeEvent(community_usage_metrics(), {
 
+#' Creates reactive table with the time since first release, the time since
+#' latest release, and the number of downloads since last year.
+com_usage_metrics <- reactive({
+  
   # Get the first package release.
   first_version <- community_usage_metrics() %>%
     filter(year == min(year)) %>%
@@ -22,14 +23,6 @@ observeEvent(community_usage_metrics(), {
   if(time_diff_first_version == 1)
     first_version_label <- str_remove(
       string = first_version_label, pattern = 's$')
-  
-  metricBoxServer(id = 'time_since_first_version',
-                  title = 'First Version Release',
-                  desc = 'Time passed since first version release',
-                  value = glue('{time_diff_first_version}
-                               {first_version_label} Ago'),
-                  succ_icon = 'black-tie',
-                  icon_class = "text-info")
   
   # Get the last package release.
   last_version <- community_usage_metrics() %>%
@@ -49,25 +42,24 @@ observeEvent(community_usage_metrics(), {
     latest_version_label <- str_remove(
       string = latest_version_label, pattern = 's$')
   
-  metricBoxServer(id = 'time_since_latest_version',
-                  title = 'Lastest Version Release',
-                  desc = 'Time passed since latest version release',
-                  value = glue('{time_diff_latest_version}
-                               {latest_version_label} Ago'),
-                  succ_icon = 'meteor',
-                  icon_class = "text-info")
-  
   downloads_last_year <- community_usage_metrics() %>%
     filter(year == year(Sys.Date()) - 1) %>%
     distinct(year, month, downloads)
   
-  metricBoxServer(id = 'downloads_last_year',
-                  title = 'Package Downloads',
-                  desc = 'Number of downloads since last year',
-                  value = format(sum(downloads_last_year$downloads), big.mark = ","),
-                  succ_icon = 'box-open',
-                  icon_class = "text-info")
+  tibble(id = c('time_since_first_version', 'time_since_latest_version', 'downloads_last_year'),
+         title = c('First Version Release', 'Lastest Version Release', 'Package Downloads'),
+         desc = c('Time passed since first version release', 'Time passed since latest version release', 'Number of downloads since last year'),
+         value = c(glue('{time_diff_first_version}{first_version_label} Ago'), glue('{time_diff_latest_version}{latest_version_label} Ago'), format(sum(downloads_last_year$downloads), big.mark = ",")),
+         succ_icon = c('black-tie', 'meteor', 'box-open'),
+         icon_class = c("text-info", "text-info", "text-info"))
 })
+
+#' Creates three metricBoxes: the time since first release, the time since
+#' latest release, and the number of downloads since last year.
+observeEvent(com_usage_metrics(), {
+  pmap(com_usage_metrics(), metricBoxServer)
+})
+
 
 # Call module to create comments and save the output.
 cum_comment_added <- addCommentServer(id = "add_comment_for_cum",

--- a/Server/reportpreview.R
+++ b/Server/reportpreview.R
@@ -23,6 +23,7 @@ viewCommentsServer(id = "view_overall_comments_for_report",
                    label = 'Overall Comments')
 
 metricGridServer("report_mm_metricGrid", metrics = maint_metrics)
+metricGridServer("report_cum_metricGrid", metrics = com_usage_metrics)
 
 # Display general information of the selected package.
 output$pkg_overview <- renderUI({

--- a/UI/reportpreview.R
+++ b/UI/reportpreview.R
@@ -48,7 +48,7 @@ output$report_preview <- renderUI({
           hr(),
           fluidRow(
             h5("Community Usage Metrics"),
-            #metricGridUI("report_mm_metricGrid"),
+            metricGridUI("report_cum_metricGrid"),
             viewCommentsUI("view_cum_comments_for_report")
           )
         )


### PR DESCRIPTION
This is a draft fix for #169. Further work needs to be done for community usage metrics to be incorporated.