### PR TITLE
sidebar minor update

### DIFF
--- a/R/sidebar.R
+++ b/R/sidebar.R
@@ -77,7 +77,6 @@ sidebarServer <- function(id, uploaded_pkgs, user) {
       
       updateSelectizeInput(
         inputId = "select_pkg",
-        #label = h5("Select Package"),
         choices = c("-", dbSelect('SELECT name FROM package')$name),
         selected = "-"
       )
@@ -120,7 +119,7 @@ sidebarServer <- function(id, uploaded_pkgs, user) {
       if(input$select_ver == "-")
         validate("Please select a version")
       
-      status <- ifelse(selected_pkg()$decision == "", "Under Review", "Reviewed")
+      status <- ifelse(selected_pkg()$decision == '', "Under Review", "Reviewed")
       h5(status)
     })
     
@@ -191,35 +190,39 @@ sidebarServer <- function(id, uploaded_pkgs, user) {
                No - Exits from window and removes the text in comment box."
           ),
           footer = tagList(
-            actionButton(NS(id, "submit_overall_comment_yes"), "Yes", class = "btn-success"),
-            actionButton(NS(id, "submit_overall_comment_edit"), "Edit", class = "btn-secondary"),
-            actionButton(NS(id, "submit_overall_comment_no"), "No", class = "btn-unsuccess")
+            actionButton(NS(id, "submit_overall_comment_yes"), "Yes"),
+            actionButton(NS(id, "submit_overall_comment_edit"), "Edit"),
+            actionButton(NS(id, "submit_overall_comment_no"), "No")
           )
         ))
       } else{
         dbUpdate(glue(
           "INSERT INTO comments
-          VALUES ('{selected_pkg()$name}', '{user$name}', '{user$role}', '{current_comment}', 'o', '{getTimeStamp()}')"))
+          VALUES ('{selected_pkg()$name}', '{user$name}', '{user$role}',
+          '{current_comment}', 'o', '{getTimeStamp()}')"))
         
-        updateTextAreaInput(session, "overall_comment", placeholder = paste("current comment:", current_comment))
+        updateTextAreaInput(session, "overall_comment",
+                            placeholder = glue('Current Comment: {current_comment}'))
       }
     })
     
     observeEvent(input$submit_overall_comment_yes, {
 
       req(selected_pkg())
-      
-      command <-glue(
-        "UPDATE comments
+
+      dbUpdate(
+        glue(
+          "UPDATE comments
           SET comment = '{input$overall_comment}', added_on = '{getTimeStamp()}'
           WHERE id = '{selected_pkg()$name}' AND
           user_name = '{user$name}' AND
           user_role = '{user$role}' AND
           comment_type = 'o'"
+        )
       )
-      dbUpdate(command)
       current_comment <- trimws(input$overall_comment)
-      updateTextAreaInput(session, "overall_comment", value = "", placeholder = paste("current comment:", current_comment))
+      updateTextAreaInput(session, "overall_comment", value = "",
+                          placeholder = glue('Current Comment: {current_comment}'))
       removeModal()
     })
 

--- a/R/sidebar.R
+++ b/R/sidebar.R
@@ -100,9 +100,6 @@ sidebarServer <- function(id, uploaded_pkgs, user) {
     observeEvent(input$select_pkg, {
       req(input$select_pkg)
       
-      if(input$select_pkg == "-")
-        validate("Please select a package")
-      
       version <- ifelse(input$select_pkg == "-", "-", selected_pkg()$version)
       
       updateSelectizeInput(

--- a/R/sidebar.R
+++ b/R/sidebar.R
@@ -88,8 +88,7 @@ sidebarServer <- function(id, uploaded_pkgs, user) {
     selected_pkg <- reactive({
       req(input$select_pkg)
       req(input$select_ver)
-      req(input$select_pkg != "-")
-      
+
       dbSelect(glue(
         "SELECT *
         FROM package
@@ -99,6 +98,7 @@ sidebarServer <- function(id, uploaded_pkgs, user) {
     # Update package version.
     observeEvent(input$select_pkg, {
       req(input$select_pkg)
+      req(input$select_ver)
       
       version <- ifelse(input$select_pkg == "-", "-", selected_pkg()$version)
       
@@ -169,6 +169,8 @@ sidebarServer <- function(id, uploaded_pkgs, user) {
       if(current_comment == "")
         validate("Please enter a comment.")
       
+      req(selected_pkg())
+      
       previous_comments <- 
         dbSelect(glue(
           "SELECT *
@@ -205,6 +207,8 @@ sidebarServer <- function(id, uploaded_pkgs, user) {
     
     observeEvent(input$submit_overall_comment_yes, {
 
+      req(selected_pkg())
+      
       command <-glue(
         "UPDATE comments
           SET comment = '{input$overall_comment}', added_on = '{getTimeStamp()}'


### PR DESCRIPTION
remove validate() from update package version step.

One thing I noticed was that 
when you select a package and then go and select "-"
the version does not get reset to "-"

This is because of this piece of code in the "update package version" step
```{r, eval=FALSE}
      if(input$select_pkg == "-")
        validate("Please select a package")
```