### PR TITLE
Admin mode fixes

### DIFF
--- a/app.R
+++ b/app.R
@@ -121,10 +121,37 @@ add_tags <- function(ui, ...) {
   ui <- force(ui)
   
   function(request) {
+    query <- parseQueryString(request$QUERY_STRING)
+    admin <- query$admin
+    
   if (is.function(ui)) {
     ui <- ui(request)
   }
-  tagList(ui, tags$script(HTML("document.getElementById('admin-add_user').style.width = 'auto';")))
+  
+  if (identical(admin, "true")) {
+    tagList(ui, 
+            tags$script(HTML("document.getElementById('admin-add_user').style.width = 'auto';")),
+            tags$script(HTML("var paragraphs = Array.prototype.slice.call(document.getElementsByClassName('mfb-component--br'), 0);
+                             for (var i = 0; i < paragraphs.length; ++i) {
+                               paragraphs[i].remove();
+                             }")),
+            fab_button(
+              position = "bottom-right",
+              actionButton(
+                inputId = ".shinymanager_logout",
+                label = "Logout",
+                icon = icon("sign-out-alt")
+              ),
+              actionButton(
+                inputId = ".shinymanager_app",
+                label = "Go to application",
+                icon = icon("share")
+              )
+            )
+            )
+  } else {
+    tagList(ui)
+  }
   }
 }
 

--- a/app.R
+++ b/app.R
@@ -34,6 +34,23 @@ ui <- fluidPage(
   useShinyjs(),
   waiter::use_waitress(),
   
+  tags$script(HTML(
+    "$(function() {
+
+  // trigger redraw of sparklines after each event value
+  $(document).on({
+    'shiny:value': function(event) {
+      if (event.name === 'tabPanel') {
+        // defer to next tick to add sparklines
+        setTimeout(function() {
+          document.getElementById('admin-add_user').style.width = 'auto';
+        }, 0)
+      }
+    }
+  });
+});"
+  )),
+  
   theme = theme,
   
   includeCSS(path = "www/css/main.css"),

--- a/app.R
+++ b/app.R
@@ -39,63 +39,8 @@ ui <- fluidPage(
   includeCSS(path = "www/css/main.css"),
   includeCSS(path = "www/css/community_metrics.css"),
   
-  tabsetPanel(
-    id = "apptabs",
-    tabPanel(
-      title = "Risk Assessment",
-      icon = icon("clipboard-list"),
-      
-      titlePanel(
-        windowTitle = "Risk Assessment",
-        title = div(id = "page-title", "R Package Risk Assessment App")
-      ),
-      
-      sidebarLayout(
-        sidebarPanel = sidebarPanel(
-          width = 4,
-          sidebarUI("sidebar")
-        ),
-        
-        mainPanel = mainPanel(
-          width = 8,
-          tabsetPanel(
-            id = "tabs",
-            tabPanel(
-              id = "upload_tab_id",
-              title = "Upload Package",
-              uploadPackageUI("upload_package")
-            ),
-            tabPanel(
-              id = "mm_tab_id",
-              title = "Maintenance Metrics",
-              maintenanceMetricsUI('maintenanceMetrics')
-            ),
-            tabPanel(
-              id = "cum_tab_id",
-              title = "Community Usage Metrics",
-              communityMetricsUI('communityMetrics')
-            ),
-            tabPanel(
-              id = "reportPreview_tab_id",
-              title = "Report Preview",
-              reportPreviewUI("reportPreview")  # UI for Report Preview tab Panel
-            )
-          )
-        )
-      )
-    ), 
-    
-    tabPanel(
-      title = div(id = "database-tab", icon("database"), "Database"),
-      databaseViewUI("databaseView")
-    ),
-    
-    tabPanel(
-      title = div(id = "assessment-criteria-tab", icon("info-circle"), "Assessment Criteria"),
-      assessmentInfoUI("assessmentInfo")
-    )
-  ),
-  
+  uiOutput("tabPanel"),
+
   footer =
     wellPanel(
       id = "footer",
@@ -128,6 +73,125 @@ server <- function(session, input, output) {
       passphrase = key_get("R-shinymanager-key", getOption("keyring_user"))
     )
   )
+  
+  output$tabPanel <- renderUI({
+    if (res_auth$admin == TRUE) {
+      tabsetPanel(
+        id = "apptabs",
+        tabPanel(
+          title = "Risk Assessment",
+          icon = icon("clipboard-list"),
+          
+          titlePanel(
+            windowTitle = "Risk Assessment",
+            title = div(id = "page-title", "R Package Risk Assessment App")
+          ),
+          
+          sidebarLayout(
+            sidebarPanel = sidebarPanel(
+              width = 4,
+              sidebarUI("sidebar")
+            ),
+            
+            mainPanel = mainPanel(
+              width = 8,
+              tabsetPanel(
+                id = "tabs",
+                tabPanel(
+                  id = "upload_tab_id",
+                  title = "Upload Package",
+                  uiOutput("upload_package")  # UI for upload package tab panel.
+                ),
+                tabPanel(
+                  id = "mm_tab_id",
+                  value = "mm_tab_value",
+                  title = "Maintenance Metrics",
+                  uiOutput("maintenance_metrics") # UI for Maintenance Metrics tab panel.
+                ),
+                tabPanel(
+                  id = "cum_tab_id",
+                  value = "cum_tab_value",
+                  title = "Community Usage Metrics",
+                  uiOutput("community_usage_metrics")  # UI for Community Usage Metrics tab panel.
+                ),
+                tabPanel(
+                  id = "reportPreview_tab_id",
+                  title = "Report Preview",
+                  uiOutput("report_preview")  # UI for Report Preview tab Panel
+                )
+              )
+            )
+          )
+        ), 
+        
+        tabPanel(
+          title = div(id = "database-tab", icon("database"), "Database"),
+          databaseViewUI("databaseView")
+        ),
+        
+        tabPanel(
+          title = div(id = "administrative-tab", icon("cogs"), "Administrative Tools"),
+          assessmentInfoUI("assessmentInfo"),
+          shinymanager:::admin_ui("admin")
+        )
+      )
+    } else {
+      tabsetPanel(
+        id = "apptabs",
+        tabPanel(
+          title = "Risk Assessment",
+          icon = icon("clipboard-list"),
+          
+          titlePanel(
+            windowTitle = "Risk Assessment",
+            title = div(id = "page-title", "R Package Risk Assessment App")
+          ),
+          
+          sidebarLayout(
+            sidebarPanel = sidebarPanel(
+              width = 4,
+              sidebarUI("sidebar")
+            ),
+            
+            mainPanel = mainPanel(
+              width = 8,
+              tabsetPanel(
+                id = "tabs",
+                tabPanel(
+                  id = "upload_tab_id",
+                  title = "Upload Package",
+                  uiOutput("upload_package")  # UI for upload package tab panel.
+                ),
+                tabPanel(
+                  id = "mm_tab_id",
+                  value = "mm_tab_value",
+                  title = "Maintenance Metrics",
+                  uiOutput("maintenance_metrics") # UI for Maintenance Metrics tab panel.
+                ),
+                tabPanel(
+                  id = "cum_tab_id",
+                  value = "cum_tab_value",
+                  title = "Community Usage Metrics",
+                  uiOutput("community_usage_metrics")  # UI for Community Usage Metrics tab panel.
+                ),
+                tabPanel(
+                  id = "reportPreview_tab_id",
+                  title = "Report Preview",
+                  uiOutput("report_preview")  # UI for Report Preview tab Panel
+                )
+              )
+            )
+          )
+        ), 
+        
+        tabPanel(
+          title = div(id = "database-tab", icon("database"), "Database"),
+          databaseViewUI("databaseView")
+        ),
+        
+      )
+    }
+  })
   
   # Save user name and role.  
   observeEvent(res_auth$user, {

--- a/app.R
+++ b/app.R
@@ -147,6 +147,9 @@ server <- function(session, input, output) {
   purrr::walk(c("admin-edited_user", "admin-edited_mult_user", "admin-delete_selected_users", "admin-delete_user"),
              ~ observeEvent(input[[.x]], removeModal(), priority = -1))
   
+  purrr::walk(c("admin-reseted_password", "admin-changed_password", "admin-added_user"),
+              ~ observeEvent(input[[.x]], shinyjs::runjs("document.body.setAttribute('data-bs-overflow', 'auto');"), priority = -1))
+  
 
   # Save user name and role.  
   observeEvent(res_auth$user, {

--- a/app.R
+++ b/app.R
@@ -117,6 +117,19 @@ ui <- shinymanager::secure_app(
     tags$h2("Risk Assessment Application", style = "align:center")),
   enable_admin = TRUE, theme = theme)
 
+add_tags <- function(ui, ...) {
+  ui <- force(ui)
+  
+  function(request) {
+  if (is.function(ui)) {
+    ui <- ui(request)
+  }
+  tagList(ui, tags$script(HTML("document.getElementById('admin-add_user').style.width = 'auto';")))
+  }
+}
+
+ui <- add_tags(ui)
+
 # Create Server Code.
 server <- function(session, input, output) {
   

--- a/app.R
+++ b/app.R
@@ -38,7 +38,7 @@ ui <- fluidPage(
   
   includeCSS(path = "www/css/main.css"),
   includeCSS(path = "www/css/community_metrics.css"),
-  
+
   tabsetPanel(
     id = "apptabs",
     tabPanel(
@@ -142,7 +142,11 @@ server <- function(session, input, output) {
     } else {
       removeTab(inputId = "apptabs", target = "admin-mode-tab")
     }
-  })  
+  }, priority = 1)
+  
+  purrr::walk(c("admin-edited_user", "admin-edited_mult_user", "admin-delete_selected_users", "admin-delete_user"),
+             ~ observeEvent(input[[.x]], removeModal(), priority = -1))
+  
 
   # Save user name and role.  
   observeEvent(res_auth$user, {

--- a/app.R
+++ b/app.R
@@ -63,24 +63,22 @@ ui <- fluidPage(
             tabPanel(
               id = "upload_tab_id",
               title = "Upload Package",
-              uiOutput("upload_package")  # UI for upload package tab panel.
+              uploadPackageUI("upload_package")
             ),
             tabPanel(
               id = "mm_tab_id",
-              value = "mm_tab_value",
               title = "Maintenance Metrics",
-              uiOutput("maintenance_metrics") # UI for Maintenance Metrics tab panel.
+              maintenanceMetricsUI("maintenanceMetrics")
             ),
             tabPanel(
               id = "cum_tab_id",
-              value = "cum_tab_value",
               title = "Community Usage Metrics",
-              uiOutput("community_usage_metrics")  # UI for Community Usage Metrics tab panel.
+              communityMetricsUI("communityMetrics")
             ),
             tabPanel(
               id = "reportPreview_tab_id",
               title = "Report Preview",
-              uiOutput("report_preview")  # UI for Report Preview tab Panel
+              reportPreviewUI("reportPreview")
             )
           )
         )


### PR DESCRIPTION
So far I have used a similar approach as @Robert-Krajcik. Instead of using `shinyjs::hide`, I have used a render UI based on if the user was authorized as an administrator. This places the logic for displaying the admin UI in the server logic as opposed to the interface. This keeps users from being able to access the admin tab by editing the HTML or running JavaScript.