### PR TITLE
Minor Package Upload revamping to improve Community Metrics

### DIFF
--- a/R/communityMetrics.R
+++ b/R/communityMetrics.R
@@ -53,56 +53,43 @@ communityMetricsServer <- function(id, selected_pkg, community_metrics, user) {
       first_version <- community_metrics() %>%
         filter(year == min(year)) %>%
         filter(month == min(month)) %>%
-        slice_head(n = 1)
-
-      # Get difference between today and first release in years.
-      time_diff_first_version <- year(Sys.Date()) - first_version$year
-      first_version_label <- 'Years'
-      if(time_diff_first_version == 0){
-        # Get difference in months.
-        time_diff_first_version <- month(Sys.Date()) - first_version$month
-        first_version_label <- 'Months'
-      }
-      if(time_diff_first_version == 1)
-        first_version_label <- str_remove(
-          string = first_version_label, pattern = 's$')
+        slice_head(n = 1) %>%
+        mutate(fake_rel_date = lubridate::make_date(year, month, 15))
+      
+      # get the time span in months or years depending on how much time
+      # has elapsed
+      time_diff_first_rel <- get_date_span(first_version$fake_rel_date)
       
       cards <- data.frame(
         name = 'time_since_first_version',
         title = 'First Version Release',
         desc = 'Time passed since first version release',
-        value = glue('{time_diff_first_version} {first_version_label} Ago'),
+        value = glue('{time_diff_first_rel$value} {time_diff_first_rel$label} Ago'),
         succ_icon = 'black-tie',
         icon_class = "text-info",
         is_perc = 0,
         is_url = 0
       )
       
-      # Get the last package release.
-      last_version <- community_metrics() %>%
-        filter(version != "NA") %>%
+      
+      # Get the last package release's month and year, then
+      # make add in the release date
+      last_ver <- community_metrics() %>%
+        filter(!(version %in% c('', 'NA'))) %>%
         filter(year == max(year)) %>%
         filter(month == max(month)) %>%
-        slice_head(n = 1)
-
-      # Get difference between today and latest release.
-      time_diff_latest_version <- year(Sys.Date()) - last_version$year
-      latest_version_label <- 'Years'
-      if(time_diff_latest_version == 0) {
-        # Get difference in months.
-        time_diff_latest_version <- month(Sys.Date()) - last_version$month
-        latest_version_label <- 'Months'
-      }
-      # remove "s" off of "Years" or "Months" if 1
-      if(time_diff_latest_version == 1)
-        latest_version_label <- str_remove(
-          string = latest_version_label, pattern = 's$')
+        slice_head(n = 1) %>%
+        mutate(fake_rel_date = lubridate::make_date(year, month, 15))
+      
+      # get the time span in months or years depending on how much time
+      # has elapsed
+      time_diff_latest_rel <- get_date_span(last_ver$fake_rel_date)
       
       cards <- cards %>%
         add_row(name = 'time_since_latest_version',
                 title = 'Latest Version Release',
                 desc = 'Time passed since latest version release',
-                value = glue('{time_diff_latest_version} {latest_version_label} Ago'),
+                value = glue('{time_diff_latest_rel$value} {time_diff_latest_rel$label} Ago'),
                 succ_icon = 'meteor',
                 icon_class = "text-info",
                 is_perc = 0,

--- a/R/communityMetrics.R
+++ b/R/communityMetrics.R
@@ -80,10 +80,11 @@ communityMetricsServer <- function(id, selected_pkg, community_metrics, user) {
       
       # Get the last package release.
       last_version <- community_metrics() %>%
+        filter(version != "NA") %>%
         filter(year == max(year)) %>%
         filter(month == max(month)) %>%
         slice_head(n = 1)
-      
+
       # Get difference between today and latest release.
       time_diff_latest_version <- year(Sys.Date()) - last_version$year
       latest_version_label <- 'Years'
@@ -92,13 +93,14 @@ communityMetricsServer <- function(id, selected_pkg, community_metrics, user) {
         time_diff_latest_version <- month(Sys.Date()) - last_version$month
         latest_version_label <- 'Months'
       }
+      # remove "s" off of "Years" or "Months" if 1
       if(time_diff_latest_version == 1)
         latest_version_label <- str_remove(
           string = latest_version_label, pattern = 's$')
       
       cards <- cards %>%
         add_row(name = 'time_since_latest_version',
-                title = 'Lastest Version Release',
+                title = 'Latest Version Release',
                 desc = 'Time passed since latest version release',
                 value = glue('{time_diff_latest_version} {latest_version_label} Ago'),
                 succ_icon = 'meteor',

--- a/R/dbupload.R
+++ b/R/dbupload.R
@@ -96,7 +96,6 @@ upload_package_to_db <- function(name, version, title, description,
 
 # Get the maintenance and testing metrics info and upload into DB.
 insert_maintenance_metrics_to_db <- function(pkg_name){
-  # pkg_name <- "samplesizeCMH"
   
   riskmetric_assess <-
     pkg_ref(pkg_name) %>%

--- a/R/dbupload.R
+++ b/R/dbupload.R
@@ -156,7 +156,7 @@ insert_maintenance_metrics_to_db <- function(pkg_name){
 }
 
 
-
+# Get community usage metrics info and upload into DB.
 insert_community_metrics_to_db <- function(pkg_name) {
   pkgs_cum_metrics <- tibble()
   

--- a/R/dbupload.R
+++ b/R/dbupload.R
@@ -157,11 +157,8 @@ insert_maintenance_metrics_to_db <- function(pkg_name){
 }
 
 
-# Get community usage metrics info and upload into DB.
-# pkg_name <- "samplesizeCMH"
-# pkg_name <- "rlang"
+
 insert_community_metrics_to_db <- function(pkg_name) {
-  print(pkg_name)
   pkgs_cum_metrics <- tibble()
   
   tryCatch(
@@ -220,9 +217,6 @@ insert_community_metrics_to_db <- function(pkg_name) {
         arrange(year, month) %>%
         select(-date)
       
-      print("pkgs_cum_metrics:")
-      print(pkgs_cum_metrics)
-      
     },
     error = function(e) {
       loggit("ERROR", paste("Error extracting cum metric info of the package:",
@@ -231,11 +225,7 @@ insert_community_metrics_to_db <- function(pkg_name) {
     }
   )
   
-  print(paste(pkg_name, "made it past tryCatch"))
-  print("nrow(pkgs_cum_metrics) != 0...")
-  print(nrow(pkgs_cum_metrics) != 0)
   if(nrow(pkgs_cum_metrics) != 0){
-    print(paste(pkg_name, "made it into dbUpdate!!!"))
     for (i in 1:nrow(pkgs_cum_metrics)) {
       dbUpdate(glue(
         "INSERT INTO community_usage_metrics 

--- a/R/uploadPackage.R
+++ b/R/uploadPackage.R
@@ -92,44 +92,44 @@ uploadPackageServer <- function(id) {
       
       withProgress(message = "Uploading Packages to DB:", value = 0, {
         
-      for (i in 1:nrow(uploaded_packages)) {
-        ref <- riskmetric::pkg_ref(uploaded_packages$package[i])
-      
-        incProgress(1 / (nrow(uploaded_packages) + 1), 
-                    detail = paste("package", uploaded_packages$package[i], "version", as.character(ref$version)))
+        for (i in 1:nrow(uploaded_packages)) {
+          ref <- riskmetric::pkg_ref(uploaded_packages$package[i])
         
-        
-        if (ref$source == "pkg_missing"){
-          uploaded_packages$status[i] <- 'not found'
-
-          loggit('WARN',
-                 glue('Package {ref$name} was flagged by riskmetric as {ref$source}.'))
+          incProgress(1 / (nrow(uploaded_packages) + 1), 
+                      detail = paste("package", uploaded_packages$package[i], "version", as.character(ref$version)))
           
-        }
-        else {
-          # Save version.
-          uploaded_packages$version[i] <- as.character(ref$version)
-
-          found <- nrow(dbSelect(glue(
-            "SELECT name
-            FROM package
-            WHERE name = '{uploaded_packages$package[i]}'")))
           
-          uploaded_packages$status[i] <- ifelse(found == 0, 'new', 'duplicate')
-          
-          # Add package and metrics to the db if package is not in the db.
-          if(!found) {
-            # Get and upload pkg general info to db.
-            insert_pkg_info_to_db(uploaded_packages$package[i])
-            # Get and upload maintenance metrics to db.
-            insert_maintenance_metrics_to_db(uploaded_packages$package[i])
-            # Get and upload community metrics to db.
-            insert_community_metrics_to_db(uploaded_packages$package[i])
+          if (ref$source == "pkg_missing"){
+            uploaded_packages$status[i] <- 'not found'
+  
+            loggit('WARN',
+                   glue('Package {ref$name} was flagged by riskmetric as {ref$source}.'))
+            
+          }
+          else {
+            # Save version.
+            uploaded_packages$version[i] <- as.character(ref$version)
+  
+            found <- nrow(dbSelect(glue(
+              "SELECT name
+              FROM package
+              WHERE name = '{uploaded_packages$package[i]}'")))
+            
+            uploaded_packages$status[i] <- ifelse(found == 0, 'new', 'duplicate')
+            
+            # Add package and metrics to the db if package is not in the db.
+            if(!found) {
+              # Get and upload pkg general info to db.
+              insert_pkg_info_to_db(uploaded_packages$package[i])
+              # Get and upload maintenance metrics to db.
+              insert_maintenance_metrics_to_db(uploaded_packages$package[i])
+              # Get and upload community metrics to db.
+              insert_community_metrics_to_db(uploaded_packages$package[i])
+            }
           }
         }
-      }
-        setProgress(value = 1, detail = "   **Completed Uploading Packages**")
-        Sys.sleep(0.25)
+          setProgress(value = 1, detail = "   **Completed Uploading Packages**")
+          Sys.sleep(0.25)
         
       }) #withProgress
       

--- a/R/utils.R
+++ b/R/utils.R
@@ -192,3 +192,24 @@ update_metric_weight <- function(metric_name, metric_weight){
     WHERE name = '{metric_name}'"
   ))
 }
+
+# Function accepts a start date and optional end date and will 
+get_date_span <- function(start, end = Sys.Date()) {
+  # Get approximate difference between today and latest release.
+  # time_diff_latest_version <- year(Sys.Date()) - last_ver$year
+  time_diff <- interval(start, end)
+  time_diff_val <- time_diff %/% months(1)
+  time_diff_label <- 'Months'
+  
+  if(time_diff_val >= 12) {
+    # Get difference in months.
+    time_diff_val <- time_diff %/% years(1)
+    time_diff_label <- 'Years'
+  }
+  # remove "s" off of "Years" or "Months" if 1
+  if(time_diff_val == 1)
+    time_diff_label <- str_remove(
+      string = time_diff_label, pattern = 's$')
+  return(list(value = time_diff_val, label = time_diff_label))
+}
+


### PR DESCRIPTION
This PR touches 3 files, all to improve the package upload process from a Community Metrics perspective. Specifically:

* Fixes #215. Re-wrote some of `insert_community_metrics_to_db()` so that it could produce results for ~800 packages that have only a single version release (thus meaning, they don't exist on the CRAN Archive for webscraping)
* Added additional 'steps' to progress bar while packages were loading. Previously it was only 1 step per package, now there is like 5 incremental steps per package, giving the user a better idea of load time. I also improved the progress bar messaging slightly.
* Fixes #217

Just need one person to review and merge! Thank you!