### PR TITLE
Allow admin to reset risk decision

### DIFF
--- a/R/sidebar.R
+++ b/R/sidebar.R
@@ -93,10 +93,7 @@ sidebarServer <- function(id, user, uploaded_pkgs) {
     # Get information about selected package.
     selected_pkg <- reactiveValues()
     
-    observe({
-      req(input$select_pkg)
-      req(input$select_ver)
-
+    observeEvent(input$select_pkg, {
       pkg_selected <- dbSelect(glue(
         "SELECT *
         FROM package
@@ -104,7 +101,7 @@ sidebarServer <- function(id, user, uploaded_pkgs) {
       
       pkg_selected %>%
         walk2(names(.), function(.x, .y) {selected_pkg[[.y]] <- .x})
-    })
+    }, priority = 1)
     
     # Update package version.
     observeEvent(input$select_pkg, {

--- a/R/sidebar.R
+++ b/R/sidebar.R
@@ -89,14 +89,16 @@ sidebarServer <- function(id, user, uploaded_pkgs) {
     }, ignoreNULL = TRUE)
     
     # Get information about selected package.
-    selected_pkg <- reactive({
+    selected_pkg <- reactiveVal()
+    
+    observe({
       req(input$select_pkg)
       req(input$select_ver)
 
-      dbSelect(glue(
+      selected_pkg(dbSelect(glue(
         "SELECT *
         FROM package
-        WHERE name = '{input$select_pkg}'"))
+        WHERE name = '{input$select_pkg}'")))
     })
     
     # Update package version.

--- a/R/sidebar.R
+++ b/R/sidebar.R
@@ -250,7 +250,7 @@ sidebarServer <- function(id, user, uploaded_pkgs) {
       req(input$select_ver)
       
       # Reset decision if no package/version is selected.
-      if(input$select_pkg == "-" || input$select_ver == "-") {
+      if(input$select_pkg == "-" || input$select_ver == "-" || selected_pkg$decision == "") {
         updateSliderTextInput(
           session,
           "decision",
@@ -392,6 +392,13 @@ sidebarServer <- function(id, user, uploaded_pkgs) {
       enable("submit_decision")
       enable("overall_comment")
       enable("submit_overall_comment")
+      
+      updateSliderTextInput(
+        session,
+        "decision",
+        choices = c("Low", "Medium", "High"),
+        selected = 'Low'
+      )
       
       removeModal()
       


### PR DESCRIPTION
Allows users with administrative roles to reset the risk decision for a selected package.

Additionally, I noticed that the reactive values returned from the sidebarServer module were only updating when a package is selected (i.e. they were not updated when a risk decision was submitted). I transitioned `selected_pkg` to be a `reactiveValues` element so that individual elements could be updated (e.g. `selected_pkg$decision` can be updated without reselecting the package).