### PR TITLE
Improve administrative tools

### DIFF
--- a/app.R
+++ b/app.R
@@ -127,7 +127,8 @@ add_tags <- function(ui, ...) {
   }
   
   if (identical(admin, "true")) {
-    tagList(ui, 
+    tagList(useShinyjs(),
+            ui, 
             tags$script(HTML("document.getElementById('admin-add_user').style.width = 'auto';")),
             tags$script(HTML("var paragraphs = Array.prototype.slice.call(document.getElementsByClassName('mfb-component--br'), 0);
                              for (var i = 0; i < paragraphs.length; ++i) {
@@ -187,6 +188,30 @@ server <- function(session, input, output) {
   
   purrr::walk(c("admin-reseted_password", "admin-changed_password", "admin-added_user"),
               ~ observeEvent(input[[.x]], shinyjs::runjs("document.body.setAttribute('data-bs-overflow', 'auto');"), priority = -1))
+  
+  observeEvent(input$`admin-edit_selected_users`, {
+    shinyjs::runjs(
+      "document.getElementById('admin-edit_mult_user-start-label').innerHTML = 'Start Date';
+       document.getElementById('admin-edit_mult_user-expire-label').innerHTML = 'Expiration Date';
+       document.getElementById('admin-edit_mult_user-user-label').innerHTML = 'User Name';"
+    )
+  }, priority = -1)
+  
+  observeEvent(input$`admin-edit_user`, {
+    shinyjs::runjs(
+      "document.getElementById('admin-edit_user-start-label').innerHTML = 'Start Date';
+       document.getElementById('admin-edit_user-expire-label').innerHTML = 'Expiration Date';
+       document.getElementById('admin-edit_user-user-label').innerHTML = 'User Name';"
+    )
+  }, priority = -1)
+  
+  observeEvent(input$`admin-add_user`, {
+    shinyjs::runjs(
+      "document.getElementById('admin-add_user-start-label').innerHTML = 'Start Date';
+       document.getElementById('admin-add_user-expire-label').innerHTML = 'Expiration Date';
+       document.getElementById('admin-add_user-user-label').innerHTML = 'User Name';"
+    )
+  }, priority = -1)
   
 
   # Save user name and role.  

--- a/app.R
+++ b/app.R
@@ -151,6 +151,15 @@ add_tags <- function(ui, ...) {
   } else {
     tagList(ui)
   }
+    tagList(useShinyjs(),
+            ui,
+            tags$script(HTML("$(document).on('shiny:value', function(event) {
+                             if (event.target.id === 'admin-table_users') {
+                             Shiny.onInputChange('table_users-returns', document.getElementById('admin-table_users').innerHTML)
+                             } else if (event.target.id === 'admin-table_pwds') {
+                             Shiny.onInputChange('table_pwds-returns', document.getElementById('admin-table_pwds').innerHTML)
+                             }
+                             });")))
   }
 }
 
@@ -212,6 +221,19 @@ server <- function(session, input, output) {
   
   observeEvent(input$`shinyjs-returns`, {
     purrr::walk(input$`shinyjs-returns`, ~ removeNotification(stringr::str_remove(.x, "shiny-notification-")))
+  })
+  
+  observeEvent(input$`table_users-returns`, {
+    shinyjs::runjs("
+                   $($('#admin-table_users').find('table').DataTable().column(0).header()).text('user name');
+                   $($('#admin-table_users').find('table').DataTable().column(1).header()).text('start date');
+                   $($('#admin-table_users').find('table').DataTable().column(2).header()).text('expiration date');")
+  })
+  
+  observeEvent(input$`table_pwds-returns`, {
+    shinyjs::runjs("
+                   $($('#admin-table_pwds').find('table').DataTable().column(0).header()).text('user name');
+                   $($('#admin-table_pwds').find('table').DataTable().column(3).header()).text('date last changed');")
   })
 
   # Save user name and role.  

--- a/app.R
+++ b/app.R
@@ -189,30 +189,13 @@ server <- function(session, input, output) {
   purrr::walk(c("admin-reseted_password", "admin-changed_password", "admin-added_user"),
               ~ observeEvent(input[[.x]], shinyjs::runjs("document.body.setAttribute('data-bs-overflow', 'auto');"), priority = -1))
   
-  observeEvent(input$`admin-edit_selected_users`, {
-    shinyjs::runjs(
-      "document.getElementById('admin-edit_mult_user-start-label').innerHTML = 'Start Date';
-       document.getElementById('admin-edit_mult_user-expire-label').innerHTML = 'Expiration Date';
-       document.getElementById('admin-edit_mult_user-user-label').innerHTML = 'User Name';"
-    )
-  }, priority = -1)
-  
-  observeEvent(input$`admin-edit_user`, {
-    shinyjs::runjs(
-      "document.getElementById('admin-edit_user-start-label').innerHTML = 'Start Date';
-       document.getElementById('admin-edit_user-expire-label').innerHTML = 'Expiration Date';
-       document.getElementById('admin-edit_user-user-label').innerHTML = 'User Name';"
-    )
-  }, priority = -1)
-  
-  observeEvent(input$`admin-add_user`, {
-    shinyjs::runjs(
-      "document.getElementById('admin-add_user-start-label').innerHTML = 'Start Date';
-       document.getElementById('admin-add_user-expire-label').innerHTML = 'Expiration Date';
-       document.getElementById('admin-add_user-user-label').innerHTML = 'User Name';"
-    )
-  }, priority = -1)
-  
+  purrr::walk(paste("admin", c("edit_mult_user", "edit_user", "add_user"), sep = "-"),
+              function(.x) {
+                y <- ifelse(.x == "admin-edit_mult_user", "admin-edit_selected_users", .x)
+                observeEvent(input[[y]], {
+                  shinyjs::runjs(paste0("document.getElementById('", .x, c("-start-", "-expire-", "-user-"), "label').innerHTML = ", c("'Start Date'", "'Expiration Date'", "'User Name'"), collapse = ";\n"))
+                }, priority = -1)
+              })
 
   # Save user name and role.  
   observeEvent(res_auth$user, {

--- a/app.R
+++ b/app.R
@@ -183,8 +183,8 @@ server <- function(session, input, output) {
     }
   }, priority = 1)
   
-  purrr::walk(c("admin-edited_user", "admin-edited_mult_user", "admin-delete_selected_users", "admin-delete_user"),
-             ~ observeEvent(input[[.x]], removeModal(), priority = -1))
+  purrr::walk(paste("admin", c("edited_user", "edited_mult_user", "delete_selected_users", "delete_user", "changed_password", "changed_password_users"), sep = "-"),
+             ~ observeEvent(input[[.x]], removeModal(), priority = 1))
   
   purrr::walk(c("admin-reseted_password", "admin-changed_password", "admin-added_user"),
               ~ observeEvent(input[[.x]], shinyjs::runjs("document.body.setAttribute('data-bs-overflow', 'auto');"), priority = -1))


### PR DESCRIPTION
This PR addresses #222.

It changes the label text for the modals created by `shinymanager` for creating and editing users.

Additionally it closes the notifications created by `shinymanager` after 1 second (or 1 second after the observe event is triggered). Unfortunately, since these notifications are not named, the solution was to use JS to return a list of all open notifications. At the current moment this does not seem to be an issue,