### PR TITLE
Docx report's plot for Community Metrics have a readable x-axis

### DIFF
--- a/www/reportDocx.Rmd
+++ b/www/reportDocx.Rmd
@@ -134,21 +134,27 @@ tagList(
 ```
 
 
-```{r community_metrics_plot}
-params$com_metrics_raw %>%
+```{r community_metrics_plot, fig.width=10, fig.height=5}
+
+
+d <- params$com_metrics_raw %>%
   mutate(day_month_year = glue('1-{month}-{year}')) %>%
   mutate(day_month_year = as.Date(day_month_year, "%d-%m-%Y")) %>%
   mutate(month = month.name[month]) %>%
   arrange(day_month_year) %>%
-  distinct(month, year, .keep_all = TRUE) %>%
-  ggplot(aes(x = day_month_year, y = downloads)) +
+  distinct(month, year, .keep_all = TRUE)
+
+mo <- ceiling(nrow(d) / 9)
+
+ggplot(data = d, aes(x = day_month_year, y = downloads)) +
   geom_point() +
   geom_line() +
-  scale_x_date(date_breaks = "3 months", date_labels = "%m-%Y") +
+  scale_x_date(date_breaks = glue::glue("{mo} months"), date_labels = "%m-%Y") +
   labs(
     x = 'Month/Year',
     y = 'Downloads'
-  )
+  ) +
+  theme(text = element_text(size = 16), axis.text = element_text(size=16))# angle = 30, vjust = 0.5, hjust=1))
 ```
 
 


### PR DESCRIPTION
Closes #212.

Docx Rmarkdown report now ensures there will be a maximum of 9 tick marks no matter how many month of history exist for a certain project. For example: the `stringr` package's plot looks like this:

![image](https://user-images.githubusercontent.com/17878953/160488455-9366d75c-b65f-44e4-bc25-3e3778538ea6.png)
