### PR TITLE
app.R initiated for deployment

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,5 @@ $credentials.*
 $database.*
 ^README\.Rmd$
 ^\.github$
+^app\.R$
+^rsconnect$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: riskassessment
 Title: A web app designed to interface with the `riskmetric` package
-Version: 0.0.0.9002
+Version: 0.0.0.9003
 Authors@R: as.person(c( 
     "Aaron Clark <aaron.clark@biogen.com> [aut, cre]",
     "Robert Krajcik <robert.krajcik@biogen.com> [aut]",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ BugReports: https://github.com/pharmaR/risk_assessment/issues
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.2
 Imports: 
     bslib (>= 0.3.0),
     config (>= 0.3.1),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Imports:
     loggit,
     lubridate,
     magrittr,
+    pkgload,
     plotly,
     purrr,
     readr (>= 2.0.1),

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * created a argument for `run_app()` called `login_note` which allows deployment users to add custom login notes on the authentication screen. By default, it will display a note about how to use default usernames and passwords to login for the first time.
 * fixed bug causing Community Usage metrics to not be added on Mac computers
 * fixed bug causing the report downloads to fail if no Community Metrics are available for a package. Instead a message is displayed "Community Usage Metrics not available for {package}"
+* Initiated simple `app.R` for easier deployment using `runURL("https://github.com/pharmaR/risk_assessment/archive/master.zip")` and `shiny::runGitHub('risk_assessment', 'pharmaR')`
 
 
 # riskassessment 0.0.0.9000

--- a/R/_disable_autoload.R
+++ b/R/_disable_autoload.R
@@ -1,0 +1,3 @@
+# Disabling shiny autoload
+
+# See ?shiny::loadSupport for more information

--- a/app.R
+++ b/app.R
@@ -1,0 +1,8 @@
+# Launch the ShinyApp (Do not remove this comment)
+# To deploy, run: rsconnect::deployApp()
+# Or use the blue button on top of this file
+
+pkgload::load_all(export_all = FALSE,helpers = FALSE,attach_testthat = FALSE)
+options( "golem.app.prod" = TRUE)
+riskassessment::run_app() # add parameters here (if any)
+

--- a/dev/02_dev.R
+++ b/dev/02_dev.R
@@ -160,7 +160,7 @@ usethis::use_vignette("riskmetric")
 
 
 # Before submitting a PR, run this code & update NEWS.md
-usethis::use_version("patch") #choices: "dev", "patch", "minor", "major"
+usethis::use_version("dev") #choices: "dev", "patch", "minor", "major"
 
 # Build pkg, including vignettes. Do this before updating documentation.
 devtools::build() # calls pkgbuld::build()     # X.X MB


### PR DESCRIPTION
This is in response to recent Q&A question: https://github.com/pharmaR/risk_assessment/discussions/287

Please review that use case!

I created an app.R file using 'golem::add_rstudioconnect_file()'. Which golem deployment function used isn't very important (there are three). Only downside is it did add `pkgload` as a new import... not sure how I feel about that.