### PR TITLE
feat: Ensure config file exists

### DIFF
--- a/R/app_config.R
+++ b/R/app_config.R
@@ -9,7 +9,7 @@
 #'
 #' @noRd
 app_sys <- function(...) {
-  system.file(..., package = "riskassessment")
+  system.file(..., package = "riskassessment", mustWork = TRUE)
 }
 
 


### PR DESCRIPTION
I find `mustWork` is a nice safety feature - raise an error as soon possible. 

It's also useful in your tests files. Happy to add if you want.