### PR TITLE
Update `riskmetric`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: riskassessment
 Title: A web app designed to interface with the `riskmetric` package
-Version: 3.1.1.9003
+Version: 3.1.1.9004
 Authors@R: c( 
     person("Aaron", "Clark", role = c("aut", "cre"), email = "clark.aaronchris@gmail.com"),
     person("Jeff", "Thompson", role = c("aut"),  email = "jeff.thompson51317@gmail.com", comment = "Co-Lead"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Open hyperlinks in a new tab from cards.
 * Fix bug causing app to crash with ELSE condition in rules
 * Add `inherits` to list of used configs
+* Incorporate bug fix for dependency assessment from `riskmetric`
 
 # riskassessment 3.1.1
 

--- a/manifest.json
+++ b/manifest.json
@@ -771,7 +771,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2023-12-10 10:50:07 UTC",
-        "Built": "R 4.3.3; x86_64-pc-linux-gnu; 2025-01-16 14:32:39 UTC; unix"
+        "Built": "R 4.3.3; x86_64-pc-linux-gnu; 2025-01-23 15:46:53 UTC; unix"
       }
     },
     "broom": {
@@ -947,7 +947,7 @@
         "RoxygenNote": "7.3.0",
         "Author": "Sebastien Rochette [aut, cre] (<https://orcid.org/0000-0002-1565-9313>),\n  Vincent Guyader [aut] (<https://orcid.org/0000-0003-0671-9270>),\n  Arthur Bréant [aut] (<https://orcid.org/0000-0003-1668-0963>),\n  Murielle Delmotte [aut] (<https://orcid.org/0000-0002-1339-2424>),\n  ThinkR [cph]",
         "Maintainer": "Sebastien Rochette <sebastien@thinkr.fr>",
-        "Built": "R 4.3.3; ; 2025-01-16 14:33:31 UTC; unix",
+        "Built": "R 4.3.3; ; 2025-01-23 15:47:46 UTC; unix",
         "RemoteType": "github",
         "RemoteUsername": "thinkr-open",
         "RemoteRepo": "checkhelper",
@@ -1310,7 +1310,7 @@
         "Imports": "callr,\ncranlike (>= 1.0.2),\ncurl,\ndesc (>= 1.1.0),\ndigest,\nparsedate,\nrappdirs,\nrematch2,\ntools,\nutils,\nwithr",
         "Suggests": "covr,\npingr,\ntestthat,\nzip",
         "Encoding": "UTF-8",
-        "Built": "R 4.3.3; ; 2025-01-16 14:33:43 UTC; unix",
+        "Built": "R 4.3.3; ; 2025-01-23 15:47:58 UTC; unix",
         "RemoteType": "github",
         "RemoteHost": "api.github.com",
         "RemoteUsername": "r-lib",
@@ -1346,7 +1346,7 @@
         "Packaged": "2018-11-26 09:54:46 UTC; gaborcsardi",
         "Repository": "RSPM",
         "Date/Publication": "2018-11-26 10:10:03 UTC",
-        "Built": "R 4.3.3; ; 2025-01-16 14:33:40 UTC; unix"
+        "Built": "R 4.3.3; ; 2025-01-23 15:47:55 UTC; unix"
       }
     },
     "cranlogs": {
@@ -1482,7 +1482,7 @@
         "Maintainer": "Scott Chamberlain <myrmecocystus@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2023-05-17 07:30:02 UTC",
-        "Built": "R 4.3.3; ; 2025-01-16 14:33:48 UTC; unix"
+        "Built": "R 4.3.3; ; 2025-01-23 15:48:03 UTC; unix"
       }
     },
     "curl": {
@@ -1596,7 +1596,7 @@
         "Packaged": "2017-10-22 09:14:23 UTC; gaborcsardi",
         "Repository": "RSPM",
         "Date/Publication": "2017-10-22 14:18:09 UTC",
-        "Built": "R 4.3.3; ; 2025-01-16 14:33:38 UTC; unix"
+        "Built": "R 4.3.3; ; 2025-01-23 15:47:53 UTC; unix"
       }
     },
     "desc": {
@@ -2330,7 +2330,7 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2024-02-23 09:30:02 UTC",
-        "Built": "R 4.3.3; ; 2025-01-16 14:32:21 UTC; unix"
+        "Built": "R 4.3.3; ; 2025-01-23 15:46:35 UTC; unix"
       }
     },
     "gh": {
@@ -2593,7 +2593,7 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2023-08-21 11:20:02 UTC",
-        "Built": "R 4.3.3; ; 2025-01-16 14:32:15 UTC; unix"
+        "Built": "R 4.3.3; ; 2025-01-23 15:46:29 UTC; unix"
       }
     },
     "haven": {
@@ -3790,7 +3790,7 @@
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
         "Repository": "RSPM",
         "Date/Publication": "2022-12-14 11:40:06 UTC",
-        "Built": "R 4.3.3; ; 2025-01-16 14:32:51 UTC; unix"
+        "Built": "R 4.3.3; ; 2025-01-23 15:47:05 UTC; unix"
       }
     },
     "pkgload": {
@@ -4374,7 +4374,7 @@
         "Maintainer": "Kevin Ushey <kevin@rstudio.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-02-29 01:10:07 UTC",
-        "Built": "R 4.3.3; ; 2025-01-16 15:02:57 UTC; unix"
+        "Built": "R 4.3.3; ; 2025-01-23 15:43:54 UTC; unix"
       }
     },
     "reprex": {
@@ -4432,7 +4432,7 @@
         "RoxygenNote": "7.2.3",
         "Author": "Gábor Csárdi [cre, aut, cph],\n  Hadley Wickham [aut],\n  RConsortium [cph],\n  RStudio [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
-        "Built": "R 4.3.3; ; 2025-01-16 14:34:20 UTC; unix",
+        "Built": "R 4.3.3; ; 2025-01-23 15:48:35 UTC; unix",
         "RemoteType": "github",
         "RemoteUsername": "r-lib",
         "RemoteRepo": "revdepcheck",
@@ -4498,7 +4498,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2022-08-31 13:00:11 UTC",
-        "Built": "R 4.3.3; ; 2025-01-16 14:34:24 UTC; unix"
+        "Built": "R 4.3.3; ; 2025-01-23 15:48:40 UTC; unix"
       }
     },
     "rintrojs": {
@@ -4550,18 +4550,18 @@
         "Config/testthat/edition": "3",
         "Author": "R Validation Hub [aut],\n  Doug Kelkhoff [aut],\n  Marly Gotti [aut],\n  Eli Miller [cre, aut],\n  Kevin K [aut],\n  Yilong Zhang [aut],\n  Eric Milliman [aut],\n  Juliane Manitz [aut],\n  Mark Padgham [ctb],\n  PSI special interest group Application and Implementation of\n    Methodologies in Statistics [cph]",
         "Maintainer": "Eli Miller <eli.miller@atorusresearch.com>",
-        "Built": "R 4.3.3; ; 2025-01-16 14:34:28 UTC; unix",
+        "Built": "R 4.3.3; ; 2025-01-23 15:48:43 UTC; unix",
         "RemoteType": "github",
-        "RemoteUsername": "pharmaR",
-        "RemoteRepo": "riskmetric",
-        "RemoteRef": "HEAD",
-        "RemoteSha": "7c7bf3c15c02c33bc788e1070f25302b203d6d9e",
         "RemoteHost": "api.github.com",
+        "RemoteRepo": "riskmetric",
+        "RemoteUsername": "pharmaR",
+        "RemoteRef": "HEAD",
+        "RemoteSha": "39489b26dbb3b7e5731bbcf55d975755fbb841e4",
         "GithubHost": "api.github.com",
         "GithubRepo": "riskmetric",
         "GithubUsername": "pharmaR",
         "GithubRef": "HEAD",
-        "GithubSHA1": "7c7bf3c15c02c33bc788e1070f25302b203d6d9e"
+        "GithubSHA1": "39489b26dbb3b7e5731bbcf55d975755fbb841e4"
       }
     },
     "rjson": {
@@ -5038,7 +5038,7 @@
         "Maintainer": "Victor Perrier <victor.perrier@dreamrs.fr>",
         "Repository": "RSPM",
         "Date/Publication": "2024-04-04 17:40:02 UTC",
-        "Built": "R 4.3.3; ; 2025-01-16 14:34:59 UTC; unix"
+        "Built": "R 4.3.3; ; 2025-01-23 15:49:14 UTC; unix"
       }
     },
     "shinyjs": {
@@ -5379,7 +5379,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "RSPM",
         "Date/Publication": "2023-12-02 11:50:05 UTC",
-        "Built": "R 4.3.3; x86_64-pc-linux-gnu; 2025-01-16 14:33:01 UTC; unix"
+        "Built": "R 4.3.3; x86_64-pc-linux-gnu; 2025-01-23 15:47:16 UTC; unix"
       }
     },
     "textshaping": {
@@ -6088,7 +6088,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "RSPM",
         "Date/Publication": "2018-09-17 13:10:03 UTC",
-        "Built": "R 4.3.3; ; 2025-01-16 14:32:56 UTC; unix"
+        "Built": "R 4.3.3; ; 2025-01-23 15:47:11 UTC; unix"
       }
     },
     "xtable": {
@@ -6596,7 +6596,7 @@
       "checksum": "a2eefba927d32d8c78d4e385178a93b7"
     },
     "renv.lock": {
-      "checksum": "d7b9816932ef58733e25081235f6fc78"
+      "checksum": "f880b5ebba3ea209ea914031dfefb052"
     }
   },
   "users": null

--- a/manifest.json
+++ b/manifest.json
@@ -4374,7 +4374,7 @@
         "Maintainer": "Kevin Ushey <kevin@rstudio.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-02-29 01:10:07 UTC",
-        "Built": "R 4.3.3; ; 2025-01-23 15:54:36 UTC; unix"
+        "Built": "R 4.3.3; ; 2025-01-23 16:15:10 UTC; unix"
       }
     },
     "reprex": {
@@ -4550,7 +4550,7 @@
         "Config/testthat/edition": "3",
         "Author": "R Validation Hub [aut],\n  Doug Kelkhoff [aut],\n  Marly Gotti [aut],\n  Eli Miller [cre, aut],\n  Kevin K [aut],\n  Yilong Zhang [aut],\n  Eric Milliman [aut],\n  Juliane Manitz [aut],\n  Mark Padgham [ctb],\n  PSI special interest group Application and Implementation of\n    Methodologies in Statistics [cph]",
         "Maintainer": "Eli Miller <eli.miller@atorusresearch.com>",
-        "Built": "R 4.3.3; ; 2025-01-16 19:56:36 UTC; unix",
+        "Built": "R 4.3.3; ; 2025-01-23 15:41:39 UTC; unix",
         "RemoteType": "github",
         "RemoteHost": "api.github.com",
         "RemoteRepo": "riskmetric",
@@ -6227,7 +6227,7 @@
       "checksum": "99c5575cb81828e20a7fe1d205551316"
     },
     "DESCRIPTION": {
-      "checksum": "d269be66d51c38bd3cf8d01381f75bdb"
+      "checksum": "12e481058ce37c76bd7036879d7dee13"
     },
     "inst/app/www/css/community_metrics.css": {
       "checksum": "f08eb25c2ee48ac22ed63b0d18994a04"
@@ -6470,7 +6470,7 @@
       "checksum": "97d1232340e04c53088bc8f814133dcd"
     },
     "NEWS.md": {
-      "checksum": "3f750ced5e226047c9f6fb60fd4f40b7"
+      "checksum": "4bfd8192cb4473f04cc2185e48c79e1b"
     },
     "R/app_config.R": {
       "checksum": "c2b61f270b86b6833f0ee39c44a1a440"

--- a/renv.lock
+++ b/renv.lock
@@ -2366,11 +2366,11 @@
       "Version": "0.2.4.9000",
       "Source": "GitHub",
       "RemoteType": "github",
-      "RemoteUsername": "pharmaR",
-      "RemoteRepo": "riskmetric",
-      "RemoteRef": "HEAD",
-      "RemoteSha": "7c7bf3c15c02c33bc788e1070f25302b203d6d9e",
       "RemoteHost": "api.github.com",
+      "RemoteRepo": "riskmetric",
+      "RemoteUsername": "pharmaR",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "39489b26dbb3b7e5731bbcf55d975755fbb841e4",
       "Requirements": [
         "BiocManager",
         "backports",
@@ -2389,7 +2389,7 @@
         "vctrs",
         "xml2"
       ],
-      "Hash": "74a42c9c6546b6b67b247f91007369f9"
+      "Hash": "0760a20553721c30ee74c7c62b1b052e"
     },
     "rjson": {
       "Package": "rjson",


### PR DESCRIPTION
Realized that we didn't update `riskmetric` to include the bug fix for dependencies.