### PR TITLE
Fix bug where `Decision Automation` header isn't displaying for "less privileged" roles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,11 @@
 
 Mostly minor changes here!
 
-* Open hyperlinks in a **new tab** from cards.
-* Fix bug causing app to crash with `ELSE` condition in rules
-* Add `inherits` to list of used configs
-* Incorporate bug fix for dependency assessment from `riskmetric` repo
+* Can now Open hyperlinks in a **new tab** from cards.
+* Added `inherits` to list of used configs
+* Fixed bug causing app to crash with `ELSE` condition in rules
+* Fixed bug where 'Decision Automation' header would disappear when non-risk decision automation rules existed but failed to include any that were based on the pkg risk score.
+* Incorporate newer version of `riskmetric` for dependency assessment
 
 # riskassessment 3.1.1
 

--- a/R/mod_decision_automation.R
+++ b/R/mod_decision_automation.R
@@ -511,7 +511,7 @@ mod_decision_automation_server <- function(id, user, credentials){
           ),
           uiOutput(ns("empty_auto")),
         )
-      } else if (!rlang::is_empty(auto_decision_initial)) {
+      } else if (!rlang::is_empty(risk_rule_update())) {
         tagList(
           br(),br(),
           hr(),

--- a/manifest.json
+++ b/manifest.json
@@ -4374,7 +4374,7 @@
         "Maintainer": "Kevin Ushey <kevin@rstudio.com>",
         "Repository": "RSPM",
         "Date/Publication": "2024-02-29 01:10:07 UTC",
-        "Built": "R 4.3.3; ; 2025-01-23 16:15:10 UTC; unix"
+        "Built": "R 4.3.3; ; 2025-01-27 04:47:42 UTC; unix"
       }
     },
     "reprex": {
@@ -4550,7 +4550,7 @@
         "Config/testthat/edition": "3",
         "Author": "R Validation Hub [aut],\n  Doug Kelkhoff [aut],\n  Marly Gotti [aut],\n  Eli Miller [cre, aut],\n  Kevin K [aut],\n  Yilong Zhang [aut],\n  Eric Milliman [aut],\n  Juliane Manitz [aut],\n  Mark Padgham [ctb],\n  PSI special interest group Application and Implementation of\n    Methodologies in Statistics [cph]",
         "Maintainer": "Eli Miller <eli.miller@atorusresearch.com>",
-        "Built": "R 4.3.3; ; 2025-01-23 15:41:39 UTC; unix",
+        "Built": "R 4.3.3; ; 2025-01-23 17:14:14 UTC; unix",
         "RemoteType": "github",
         "RemoteHost": "api.github.com",
         "RemoteRepo": "riskmetric",
@@ -6227,7 +6227,7 @@
       "checksum": "99c5575cb81828e20a7fe1d205551316"
     },
     "DESCRIPTION": {
-      "checksum": "12e481058ce37c76bd7036879d7dee13"
+      "checksum": "2cc9cb76a0952395d0c5699eca46b372"
     },
     "inst/app/www/css/community_metrics.css": {
       "checksum": "f08eb25c2ee48ac22ed63b0d18994a04"
@@ -6470,7 +6470,7 @@
       "checksum": "97d1232340e04c53088bc8f814133dcd"
     },
     "NEWS.md": {
-      "checksum": "4bfd8192cb4473f04cc2185e48c79e1b"
+      "checksum": "b6195b38a38523dac7db505937d94f49"
     },
     "R/app_config.R": {
       "checksum": "c2b61f270b86b6833f0ee39c44a1a440"
@@ -6512,7 +6512,7 @@
       "checksum": "505a1d327144bb1153fad488c5c1d7ab"
     },
     "R/mod_decision_automation.R": {
-      "checksum": "e22e1f4c044bc9f11c46a5fcdba33063"
+      "checksum": "69ba429d1f781c34d84e2f660e4dbc5f"
     },
     "R/mod_downloadHandler.R": {
       "checksum": "9c00f033ca9565f3a466e7381025e368"


### PR DESCRIPTION
I first noticed this bug in the webinar demo deployment:

https://rinpharma.shinyapps.io/riskassessment_shinygathering2025

I was logged in with the `reviewer` role, which means I didn't have the `auto_decision_adjust` privilege. As a result, I noticed that the "Decision Automation" header and horizontal line was missing from the `Upload Package` tab:

![image](https://github.com/user-attachments/assets/7eb608cb-f270-4877-9564-a149b44f9c2b)

I checked the "normal" demo deployment, and this wasn't the case for the `reviewer` role, which was odd. The only difference in this deployment's automation rules is that it includes rules based on pkg scores. When I checked the code base, I saw that the `auto_decision_initial` depends on the existence of an upper/lower bound-based rule existing, which explained the issue. Thus, I just changed out the conditional to point to the logical value which monitors whether or not any risk rules exist.